### PR TITLE
Feature/auto refresh settings

### DIFF
--- a/src/app/settings/server-settings.service.ts
+++ b/src/app/settings/server-settings.service.ts
@@ -1,7 +1,7 @@
 import { computed, inject, Injectable, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { DuplicatiServerService, GetApiV1ServersettingsResponse } from '../core/openapi';
-
+import { finalize, pipe } from 'rxjs';
 @Injectable({
   providedIn: 'root',
 })
@@ -18,5 +18,11 @@ export class ServerSettingsService {
         this.#serverSettings.set(res);
       },
     });
+  }
+  
+  withRefresh() {
+    return pipe(
+      finalize(() => this.refreshServerSettings())
+    );
   }
 }

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -7,7 +7,7 @@
       <p i18n>Configure your backup settings.</p>
     </div>
 
-    <button type="submit" spk-button class="raised primary" i18n [disabled]="settingsForm.untouched">
+    <button type="submit" spk-button class="raised primary" i18n [disabled]="settingsForm.untouched" (click)="submit()" >
       Save changes
     </button>
   </header>

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -140,6 +140,7 @@ export default class SettingsComponent {
         },
       })
       .pipe(
+        this.#serverSettingsService.withRefresh(),
         finalize(() => this.updatingChannel.set(false)),
         catchError(() => {
           this.updateChannel.set(prevChannel);
@@ -169,6 +170,7 @@ export default class SettingsComponent {
           },
         })
         .pipe(
+          this.#serverSettingsService.withRefresh(),
           finalize(() => this.updatingRemoteAccess.set(false)),
           catchError(() => {
             this.allowRemoteAccess.set(prevValue);
@@ -193,6 +195,7 @@ export default class SettingsComponent {
         },
       })
       .pipe(
+        this.#serverSettingsService.withRefresh(),
         finalize(() => this.updatingAllowedHosts.set(false)),
         catchError(() => {
           this.allowedHostnames.set(loadedAllowedHostnames);
@@ -219,6 +222,7 @@ export default class SettingsComponent {
         },
       })
       .pipe(
+        this.#serverSettingsService.withRefresh(),
         finalize(() => this.updatingDisableTrayIconLogin.set(false)),
         catchError(() => {
           this.disableTrayIconLogin.set(prevValue);
@@ -245,7 +249,10 @@ export default class SettingsComponent {
           'server-passphrase': this.passphrase(),
         },
       })
-      .pipe(finalize(() => this.isUpdating.set(false)))
+      .pipe(
+        this.#serverSettingsService.withRefresh(),
+        finalize(() => this.isUpdating.set(false))
+      )
       .subscribe({
         next: () => {
           this.showPassphraseForm.set(false);
@@ -325,6 +332,7 @@ export default class SettingsComponent {
           'startup-delay': startupDelay === '0s' ? '' : startupDelay,
         },
       })
+      .pipe(this.#serverSettingsService.withRefresh())
       .subscribe();
   }
 


### PR DESCRIPTION
# Settings State Refresh & Save Functionality Fix

## Issue
- Settings state wasn't automatically refreshing after immediate-apply changes
- Settings requiring explicit "Save Changes" weren't being persisted
- Usage statistics settings weren't being saved

## Changes
Added state refresh logic to ensure settings persistence across:
- Immediate-apply settings
- Manual save settings
- Usage statistics preferences

## Notes
- Implemented as one possible solution - open to alternative approaches

## Testing
Verified:
- Immediate settings changes persist after refresh
- "Save Changes" button correctly persists modifications
- Usage statistics preferences are properly saved