### PR TITLE
improve BytePipe undefined handling for unscanned sources

### DIFF
--- a/src/app/core/pipes/byte.pipe.ts
+++ b/src/app/core/pipes/byte.pipe.ts
@@ -18,14 +18,14 @@ export class BytesPipe implements PipeTransform {
   decimalPipe = inject(DecimalPipe);
 
   transform(bytes: number | string | undefined | null, longForm: boolean = false): string {
-    if (!bytes || bytes === 0) return '0 Bytes';
+    if (!bytes || bytes === 0) return '';
 
     if (typeof bytes === 'string') {
       bytes = parseInt(bytes);
     }
 
     if (isNaN(bytes)) {
-      return '0 Bytes';
+      return '';
     }
 
     const isMac = this.#isMac();
@@ -38,6 +38,7 @@ export class BytesPipe implements PipeTransform {
 
     const size = bytes / Math.pow(isMac ? 1000 : 1024, power);
     const formattedSize = this.decimalPipe.transform(size, '1.0-2');
+    if (!formattedSize) return '';
 
     return `${formattedSize} ${longForm ? units[power] : units[power].replace('Bytes', 'B')}`;
   }


### PR DESCRIPTION
Previously, the Byte pipe would return "0 bytes" for undefined/null values. This proved misleading in cases like newly created backup configurations, where a source showing "0 bytes" implied it had no data, when in fact it simply hadn't been scanned yet.

Now displays "-" for undefined/null values to better reflect uninitialized states, helping users distinguish between empty and unscanned sources.