### PR TITLE
Fix missing dialogs

### DIFF
--- a/src/app/backup/backup.state.ts
+++ b/src/app/backup/backup.state.ts
@@ -28,6 +28,8 @@ import { createGeneralForm, NONE_OPTION } from './general/general.component';
 import { RetentionType } from './options/options.component';
 import { Days, SCHEDULE_FIELD_DEFAULTS } from './schedule/schedule.component';
 import { createSourceDataForm } from './source-data/source-data.component';
+import { SparkleDialogService } from '@sparkle-ui/core';
+import { ConfirmDialogComponent } from '../core/components/confirm-dialog/confirm-dialog.component';
 
 const SMART_RETENTION = '1W:1D,4W:1W,12M:1M';
 
@@ -58,6 +60,7 @@ type DestinationDefault = {
 export class BackupState {
   #router = inject(Router);
   #sysinfo = inject(SysinfoState);
+  #dialog = inject(SparkleDialogService);  
   #dupServer = inject(DuplicatiServerService);
   #timespanLiteralService = inject(TimespanLiteralsService);
 
@@ -250,10 +253,19 @@ export class BackupState {
   }
 
   exit() {
-    // TODOS
-    // - Are you sure dialog
-    this.#resetAllForms();
-    this.#router.navigate(['/']);
+    this.#dialog.open(ConfirmDialogComponent, {
+      data: {
+        title: $localize`Confirm exit?`,
+        message: $localize`Are you sure you want to exit?`,
+        confirmText: $localize`Yes`,
+        cancelText: $localize`Cancel`,
+      },
+      closed: (res) => {
+        if (!res) return;
+        this.#resetAllForms();
+        this.#router.navigate(['/']);
+      }
+    });    
   }
 
   updateFieldsFromTargetUrl(targetUrl: string) {

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -4,11 +4,13 @@ import {
   SparkleButtonComponent,
   SparkleCardComponent,
   SparkleChipComponent,
+  SparkleDialogService,
   SparkleDividerComponent,
   SparkleIconComponent,
   SparkleMenuComponent,
   SparkleProgressBarComponent,
 } from '@sparkle-ui/core';
+import { ConfirmDialogComponent } from '../core/components/confirm-dialog/confirm-dialog.component';
 import StatusBarComponent from '../core/components/status-bar/status-bar.component';
 import { DuplicatiServerService } from '../core/openapi';
 import { BytesPipe } from '../core/pipes/byte.pipe';
@@ -38,6 +40,7 @@ import { BackupsState, OrderBy, TimeType } from '../core/states/backups.state';
 })
 export default class HomeComponent {
   #backupsState = inject(BackupsState);
+  #dialog = inject(SparkleDialogService);
   #dupServer = inject(DuplicatiServerService);
 
   MISSING_BACKUP_NAME = $localize`Backup name missing`;
@@ -67,7 +70,18 @@ export default class HomeComponent {
   }
 
   deleteBackup(id: string) {
-    window.confirm('Are you sure you want to delete this backup?') && this.#backupsState.deleteBackup(id);
+    this.#dialog.open(ConfirmDialogComponent, {
+      data: {
+        title: $localize`Confirm delete`,
+        message: $localize`Are you sure you want to delete this backup?`,
+        confirmText: $localize`Delete backup`,
+        cancelText: $localize`Cancel`,
+      },
+      closed: (res) => {
+        if (!res) return;
+        this.#backupsState.deleteBackup(id)
+      }
+    });    
   }
 
   verifyFiles(id: string) {

--- a/src/app/restore-flow/restore-flow.state.ts
+++ b/src/app/restore-flow/restore-flow.state.ts
@@ -1,7 +1,9 @@
 import { inject, Injectable, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
+import { SparkleDialogService } from '@sparkle-ui/core';
 import { finalize, forkJoin, retry, take } from 'rxjs';
+import { ConfirmDialogComponent } from '../core/components/confirm-dialog/confirm-dialog.component';
 import { DuplicatiServerService, GetBackupResultDto, IListResultFileset } from '../core/openapi';
 import { createRestoreOptionsForm } from './options/options.component';
 import { createEncryptionForm } from './restore-encryption/restore-encryption.component';
@@ -12,6 +14,7 @@ import { createRestoreSelectFilesForm } from './select-files/select-files.compon
 })
 export class RestoreFlowState {
   #router = inject(Router);
+  #dialog = inject(SparkleDialogService);
   #dupServer = inject(DuplicatiServerService);
 
   backupId = signal<string | null>(null);
@@ -78,10 +81,19 @@ export class RestoreFlowState {
   }
 
   exit() {
-    // TODOS
-    // - Are you sure dialog
-    this.#resetAllForms();
-    this.#router.navigate(['/']);
+    this.#dialog.open(ConfirmDialogComponent, {
+      data: {
+        title: $localize`Confirm exit?`,
+        message: $localize`Are you sure you want to exit?`,
+        confirmText: $localize`Yes`,
+        cancelText: $localize`Cancel`,
+      },
+      closed: (res) => {
+        if (!res) return;
+        this.#resetAllForms();
+        this.#router.navigate(['/']);
+      }
+    });
   }
 
   getVersionOptions() {

--- a/src/app/settings/remote-control/remote-control.state.ts
+++ b/src/app/settings/remote-control/remote-control.state.ts
@@ -1,7 +1,9 @@
 import { computed, effect, inject, Injectable, signal } from '@angular/core';
 
+import { ConfirmDialogComponent } from '../../core/components/confirm-dialog/confirm-dialog.component';
 import { DuplicatiServerService, RemoteControlStatusOutput } from '../../core/openapi';
 import { SysinfoState } from '../../core/states/sysinfo.state';
+import { SparkleDialogService } from '@sparkle-ui/core';
 
 type State =
   | 'connected'
@@ -19,6 +21,7 @@ type Timeout = ReturnType<typeof setTimeout>;
   providedIn: 'root',
 })
 export class RemoteControlState {
+  #dialog = inject(SparkleDialogService);
   #dupServer = inject(DuplicatiServerService);
   #sysinfo = inject(SysinfoState);
 
@@ -175,11 +178,20 @@ export class RemoteControlState {
   deleteRemoteControl() {
     const _self = this;
 
-    if (confirm('Are you sure you want to delete the remote control registration?')) {
-      _self.#dupServer.deleteApiV1RemotecontrolRegistration().subscribe({
-        next: (res) => _self.#mapRemoteControlStatus(res),
-        error: (err) => _self.#mapRemoteControlError(err),
-      });
-    }
+        this.#dialog.open(ConfirmDialogComponent, {
+          data: {
+            title: $localize`Confirm delete`,
+            message: $localize`Are you sure you want to delete the remote control registration?`,
+            confirmText: $localize`Delete registration`,
+            cancelText: $localize`Cancel`,
+          },
+          closed: (res) => {
+            if (!res) return;
+            _self.#dupServer.deleteApiV1RemotecontrolRegistration().subscribe({
+              next: (res) => _self.#mapRemoteControlStatus(res),
+              error: (err) => _self.#mapRemoteControlError(err),
+            });
+          }
+        });   
   }
 }


### PR DESCRIPTION
This adds two missing confirmation dialogs and converts to native `confirm` calls to Sparkle confirmation dialogs.