### PR TITLE
Support new list operations

### DIFF
--- a/src/app/core/components/file-tree/file-tree.component.html
+++ b/src/app/core/components/file-tree/file-tree.component.html
@@ -77,7 +77,7 @@
       *ngTemplateOutlet="recursiveTree; context: { $implicit: { children: treeStructure(), level: 0 } }"></ng-container>
   </div>
 
-  @if (!accepts()) {
+  @if (!accepts() && !isByBackupSettings()) {
     <spk-toggle
       [class.active]="_showHiddenNodes()"
       class="primary raised browse-files-toggle"

--- a/src/app/core/components/file-tree/file-tree.component.ts
+++ b/src/app/core/components/file-tree/file-tree.component.ts
@@ -581,7 +581,7 @@ export default class FileTreeComponent {
           BackupId: backupSettings.id,
           Time: backupSettings.time,
           Paths: path ? [path] : null,
-          PageSize: 10000,
+          PageSize: 0, // TODO: Add pagination support
           Page: 0,
         }}
       )
@@ -589,7 +589,7 @@ export default class FileTreeComponent {
         map((res) => {
           if (res.Error)
             throw new Error(res.Error);
-          // TODO: Handle folders larger than 10000
+
           return res.Data ?? [];
         }
       ));

--- a/src/app/core/components/file-tree/file-tree.component.ts
+++ b/src/app/core/components/file-tree/file-tree.component.ts
@@ -586,13 +586,8 @@ export default class FileTreeComponent {
         }}
       )
       .pipe(
-        map((res) => {
-          if (!res.Success)
-            throw new Error(res.Error ?? "Unknown error");
-
-          return res.Data ?? [];
-        }
-      ));
+        map((res) => res.Data ?? [])
+      );
     } else {
       const params: GetApiV1BackupByIdFilesData = {
         id: backupSettings.id + '',
@@ -604,11 +599,8 @@ export default class FileTreeComponent {
 
       return this.#dupServer.getApiV1BackupByIdFiles(params)
         .pipe(
-          map((res) => {
-            return res['Files'] ?? [];
-          }
-        ));
-
+          map((res) => res['Files'] ?? [])
+        );
     }
   }
 

--- a/src/app/core/components/file-tree/file-tree.component.ts
+++ b/src/app/core/components/file-tree/file-tree.component.ts
@@ -587,8 +587,8 @@ export default class FileTreeComponent {
       )
       .pipe(
         map((res) => {
-          if (res.Error)
-            throw new Error(res.Error);
+          if (!res.Success)
+            throw new Error(res.Error ?? "Unknown error");
 
           return res.Data ?? [];
         }

--- a/src/app/core/interceptors/http.interceptor.ts
+++ b/src/app/core/interceptors/http.interceptor.ts
@@ -50,6 +50,8 @@ export const httpInterceptor: HttpInterceptorFn = (req, next) => {
         const body = (event.body as any);
         if (body?.Success === false) {
           throw {
+            status: 200,
+            message: body?.Error ?? 'Unknown error',
             error: {
               Error: body?.Error ?? 'Unknown error'
             },
@@ -60,7 +62,7 @@ export const httpInterceptor: HttpInterceptorFn = (req, next) => {
       return event;
     }),
     catchError((error) => {
-      const errorMsg = error.error.Error || `Error Code: ${error.status}, Message: ${error.message}`;
+      const errorMsg = error.error?.Error || `Error Code: ${error.status}, Message: ${error.message}`;
 
       // Suppress error handling for proxy detection requests
       if (!IS_PROXY_DETECT_REQUEST) {

--- a/src/app/core/openapi/sdk.gen.ts
+++ b/src/app/core/openapi/sdk.gen.ts
@@ -5,7 +5,7 @@ import { HttpClient } from '@angular/common/http';
 import type { Observable } from 'rxjs';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-import type { GetApiV1CommandlineResponse, PostApiV1CommandlineData, PostApiV1CommandlineResponse, GetApiV1AcknowledgementsResponse, PostApiV1AuthRefreshResponse, PostApiV1AuthSigninData, PostApiV1AuthSigninResponse, PostApiV1AuthLoginData, PostApiV1AuthLoginResponse, PostApiV1AuthIssuesignintokenData, PostApiV1AuthIssuesignintokenResponse, PostApiV1AuthRefreshLogoutResponse, PostApiV1AuthIssuetokenByOperationData, PostApiV1AuthIssuetokenByOperationResponse, PostApiV1AuthIssueForeverTokenResponse, GetApiV1BackupdefaultsResponse, GetApiV1BackupsData, GetApiV1BackupsResponse, PostApiV1BackupsData, PostApiV1BackupsResponse, PostApiV1BackupsImportData, PostApiV1BackupsImportResponse, GetApiV1BugreportByReportidData, GetApiV1BugreportByReportidResponse, GetApiV1ChangelogData, GetApiV1ChangelogResponse, GetApiV1CommandlineByRunidData, GetApiV1CommandlineByRunidResponse, PostApiV1CommandlineByRunidAbortData, PostApiV1CommandlineByRunidAbortResponse, PostApiV1FilesystemData, PostApiV1FilesystemResponse, PostApiV1FilesystemValidateData, PostApiV1FilesystemValidateResponse, GetApiV1HypervResponse, GetApiV1HypervByKeyData, GetApiV1HypervByKeyResponse, GetApiV1LicensesResponse, GetApiV1LogdataPollData, GetApiV1LogdataPollResponse, GetApiV1LogdataLogData, GetApiV1LogdataLogResponse, GetApiV1LogdataCrashlogResponse, GetApiV1MssqlResponse, GetApiV1MssqlByKeyData, GetApiV1MssqlByKeyResponse, GetApiV1NotificationByIdData, GetApiV1NotificationByIdResponse, DeleteApiV1NotificationByIdData, DeleteApiV1NotificationByIdResponse, GetApiV1NotificationsResponse, GetApiV1RemotecontrolStatusResponse, PostApiV1RemotecontrolEnableResponse, PostApiV1RemotecontrolDisableResponse, DeleteApiV1RemotecontrolRegistrationResponse, PostApiV1RemotecontrolRegisterData, PostApiV1RemotecontrolRegisterResponse, DeleteApiV1RemotecontrolRegisterResponse, PostApiV1RemoteoperationDbpathData, PostApiV1RemoteoperationDbpathResponse, PostApiV1RemoteoperationTestData, PostApiV1RemoteoperationTestResponse, PostApiV1RemoteoperationCreateData, PostApiV1RemoteoperationCreateResponse, GetApiV1ServersettingsResponse, PatchApiV1ServersettingsData, PatchApiV1ServersettingsResponse, GetApiV1ServersettingByKeyData, GetApiV1ServersettingByKeyResponse, PutApiV1ServersettingByKeyData, PutApiV1ServersettingByKeyResponse, GetApiV1ServerstateData, GetApiV1ServerstateResponse, PostApiV1ServerstatePauseData, PostApiV1ServerstatePauseResponse, PostApiV1ServerstateResumeResponse, GetApiV1SysteminfoResponse, GetApiV1SysteminfoFiltergroupsResponse, GetApiV1TaskByTaskidData, GetApiV1TaskByTaskidResponse, PostApiV1TaskByTaskidStopData, PostApiV1TaskByTaskidStopResponse, PostApiV1TaskByTaskidAbortData, PostApiV1TaskByTaskidAbortResponse, GetApiV1UisettingsResponse, PostApiV1UisettingsData, PostApiV1UisettingsResponse, GetApiV1UisettingsBySchemeData, GetApiV1UisettingsBySchemeResponse, PatchApiV1UisettingsBySchemeData, PatchApiV1UisettingsBySchemeResponse, PostApiV1WebmoduleByModulekeyData, PostApiV1WebmoduleByModulekeyResponse, GetApiV1BackupByIdData, GetApiV1BackupByIdResponse, PutApiV1BackupByIdData, PutApiV1BackupByIdResponse, DeleteApiV1BackupByIdData, DeleteApiV1BackupByIdResponse, GetApiV1BackupByIdFilesData, GetApiV1BackupByIdFilesResponse, GetApiV1BackupByIdLogData, GetApiV1BackupByIdLogResponse, GetApiV1BackupByIdRemotelogData, GetApiV1BackupByIdRemotelogResponse, GetApiV1BackupByIdFilesetsData, GetApiV1BackupByIdFilesetsResponse, GetApiV1BackupByIdExportArgsonlyData, GetApiV1BackupByIdExportArgsonlyResponse, GetApiV1BackupByIdExportCmdlineData, GetApiV1BackupByIdExportCmdlineResponse, GetApiV1BackupByIdExportData, GetApiV1BackupByIdExportResponse, GetApiV1BackupByIdIsdbusedelsewhereData, GetApiV1BackupByIdIsdbusedelsewhereResponse, GetApiV1BackupByIdIsactiveData, GetApiV1BackupByIdIsactiveResponse, PostApiV1BackupByIdDeletedbData, PostApiV1BackupByIdDeletedbResponse, PostApiV1BackupByIdMovedbData, PostApiV1BackupByIdMovedbResponse, PostApiV1BackupByIdUpdatedbData, PostApiV1BackupByIdUpdatedbResponse, PostApiV1BackupByIdRestoreData, PostApiV1BackupByIdRestoreResponse, PostApiV1BackupByIdCreatereportData, PostApiV1BackupByIdCreatereportResponse, PostApiV1BackupByIdRepairData, PostApiV1BackupByIdRepairResponse, PostApiV1BackupByIdRepairupdateData, PostApiV1BackupByIdRepairupdateResponse, PostApiV1BackupByIdVacuumData, PostApiV1BackupByIdVacuumResponse, PostApiV1BackupByIdVerifyData, PostApiV1BackupByIdVerifyResponse, PostApiV1BackupByIdCompactData, PostApiV1BackupByIdCompactResponse, PostApiV1BackupByIdStartData, PostApiV1BackupByIdStartResponse, PostApiV1BackupByIdRunData, PostApiV1BackupByIdRunResponse, PostApiV1BackupByIdReportRemoteSizeData, PostApiV1BackupByIdReportRemoteSizeResponse, PostApiV1BackupByIdCopytotempData, PostApiV1BackupByIdCopytotempResponse, GetApiV1ProgressstateResponse, GetApiV1TasksResponse, PostApiV1UpdatesCheckResponse, GetApiV1WebmodulesResponse } from './types.gen';
+import type { GetApiV1CommandlineResponse, PostApiV1CommandlineData, PostApiV1CommandlineResponse, GetApiV1AcknowledgementsResponse, PostApiV1AuthRefreshResponse, PostApiV1AuthSigninData, PostApiV1AuthSigninResponse, PostApiV1AuthLoginData, PostApiV1AuthLoginResponse, PostApiV1AuthIssuesignintokenData, PostApiV1AuthIssuesignintokenResponse, PostApiV1AuthRefreshLogoutResponse, PostApiV1AuthIssuetokenByOperationData, PostApiV1AuthIssuetokenByOperationResponse, PostApiV1AuthIssueForeverTokenResponse, GetApiV1BackupdefaultsResponse, GetApiV1BackupsData, GetApiV1BackupsResponse, PostApiV1BackupsData, PostApiV1BackupsResponse, PostApiV1BackupsImportData, PostApiV1BackupsImportResponse, GetApiV1BugreportByReportidData, GetApiV1BugreportByReportidResponse, GetApiV1ChangelogData, GetApiV1ChangelogResponse, GetApiV1CommandlineByRunidData, GetApiV1CommandlineByRunidResponse, PostApiV1CommandlineByRunidAbortData, PostApiV1CommandlineByRunidAbortResponse, PostApiV1FilesystemData, PostApiV1FilesystemResponse, PostApiV1FilesystemValidateData, PostApiV1FilesystemValidateResponse, GetApiV1HypervResponse, GetApiV1HypervByKeyData, GetApiV1HypervByKeyResponse, GetApiV1LicensesResponse, GetApiV1LogdataPollData, GetApiV1LogdataPollResponse, GetApiV1LogdataLogData, GetApiV1LogdataLogResponse, GetApiV1LogdataCrashlogResponse, GetApiV1MssqlResponse, GetApiV1MssqlByKeyData, GetApiV1MssqlByKeyResponse, GetApiV1NotificationByIdData, GetApiV1NotificationByIdResponse, DeleteApiV1NotificationByIdData, DeleteApiV1NotificationByIdResponse, GetApiV1NotificationsResponse, GetApiV1RemotecontrolStatusResponse, PostApiV1RemotecontrolEnableResponse, PostApiV1RemotecontrolDisableResponse, DeleteApiV1RemotecontrolRegistrationResponse, PostApiV1RemotecontrolRegisterData, PostApiV1RemotecontrolRegisterResponse, DeleteApiV1RemotecontrolRegisterResponse, PostApiV1RemoteoperationDbpathData, PostApiV1RemoteoperationDbpathResponse, PostApiV1RemoteoperationTestData, PostApiV1RemoteoperationTestResponse, PostApiV1RemoteoperationCreateData, PostApiV1RemoteoperationCreateResponse, GetApiV1ServersettingsResponse, PatchApiV1ServersettingsData, PatchApiV1ServersettingsResponse, GetApiV1ServersettingByKeyData, GetApiV1ServersettingByKeyResponse, PutApiV1ServersettingByKeyData, PutApiV1ServersettingByKeyResponse, GetApiV1ServerstateData, GetApiV1ServerstateResponse, PostApiV1ServerstatePauseData, PostApiV1ServerstatePauseResponse, PostApiV1ServerstateResumeResponse, GetApiV1SysteminfoResponse, GetApiV1SysteminfoFiltergroupsResponse, GetApiV1TaskByTaskidData, GetApiV1TaskByTaskidResponse, PostApiV1TaskByTaskidStopData, PostApiV1TaskByTaskidStopResponse, PostApiV1TaskByTaskidAbortData, PostApiV1TaskByTaskidAbortResponse, GetApiV1UisettingsResponse, PostApiV1UisettingsData, PostApiV1UisettingsResponse, GetApiV1UisettingsBySchemeData, GetApiV1UisettingsBySchemeResponse, PatchApiV1UisettingsBySchemeData, PatchApiV1UisettingsBySchemeResponse, PostApiV1WebmoduleByModulekeyData, PostApiV1WebmoduleByModulekeyResponse, GetApiV1BackupByIdData, GetApiV1BackupByIdResponse, PutApiV1BackupByIdData, PutApiV1BackupByIdResponse, DeleteApiV1BackupByIdData, DeleteApiV1BackupByIdResponse, GetApiV1BackupByIdFilesData, GetApiV1BackupByIdFilesResponse, GetApiV1BackupByIdLogData, GetApiV1BackupByIdLogResponse, GetApiV1BackupByIdRemotelogData, GetApiV1BackupByIdRemotelogResponse, GetApiV1BackupByIdFilesetsData, GetApiV1BackupByIdFilesetsResponse, GetApiV1BackupByIdExportArgsonlyData, GetApiV1BackupByIdExportArgsonlyResponse, GetApiV1BackupByIdExportCmdlineData, GetApiV1BackupByIdExportCmdlineResponse, GetApiV1BackupByIdExportData, GetApiV1BackupByIdExportResponse, GetApiV1BackupByIdIsdbusedelsewhereData, GetApiV1BackupByIdIsdbusedelsewhereResponse, GetApiV1BackupByIdIsactiveData, GetApiV1BackupByIdIsactiveResponse, PostApiV1BackupByIdDeletedbData, PostApiV1BackupByIdDeletedbResponse, PostApiV1BackupByIdMovedbData, PostApiV1BackupByIdMovedbResponse, PostApiV1BackupByIdUpdatedbData, PostApiV1BackupByIdUpdatedbResponse, PostApiV1BackupByIdRestoreData, PostApiV1BackupByIdRestoreResponse, PostApiV1BackupByIdCreatereportData, PostApiV1BackupByIdCreatereportResponse, PostApiV1BackupByIdRepairData, PostApiV1BackupByIdRepairResponse, PostApiV1BackupByIdRepairupdateData, PostApiV1BackupByIdRepairupdateResponse, PostApiV1BackupByIdVacuumData, PostApiV1BackupByIdVacuumResponse, PostApiV1BackupByIdVerifyData, PostApiV1BackupByIdVerifyResponse, PostApiV1BackupByIdCompactData, PostApiV1BackupByIdCompactResponse, PostApiV1BackupByIdStartData, PostApiV1BackupByIdStartResponse, PostApiV1BackupByIdRunData, PostApiV1BackupByIdRunResponse, PostApiV1BackupByIdReportRemoteSizeData, PostApiV1BackupByIdReportRemoteSizeResponse, PostApiV1BackupByIdCopytotempData, PostApiV1BackupByIdCopytotempResponse, PostApiV2BackupListFilesetsData, PostApiV2BackupListFilesetsResponse, PostApiV2BackupListFolderData, PostApiV2BackupListFolderResponse, PostApiV2BackupListVersionsData, PostApiV2BackupListVersionsResponse, PostApiV2BackupSearchData, PostApiV2BackupSearchResponse, GetApiV1ProgressstateResponse, GetApiV1TasksResponse, PostApiV1UpdatesCheckResponse, GetApiV1WebmodulesResponse } from './types.gen';
 
 @Injectable({
     providedIn: 'root'
@@ -1352,6 +1352,66 @@ export class DuplicatiServerService {
             path: {
                 id: data.id
             }
+        });
+    }
+    
+    /**
+     * @param data The data for the request.
+     * @param data.requestBody
+     * @returns ListFilesetsResponseDto Success
+     * @throws ApiError
+     */
+    public postApiV2BackupListFilesets(data: PostApiV2BackupListFilesetsData): Observable<PostApiV2BackupListFilesetsResponse> {
+        return __request(OpenAPI, this.http, {
+            method: 'POST',
+            url: '/api/v2/backup/list-filesets',
+            body: data.requestBody,
+            mediaType: 'application/json'
+        });
+    }
+    
+    /**
+     * @param data The data for the request.
+     * @param data.requestBody
+     * @returns ListFolderContentResponseDto Success
+     * @throws ApiError
+     */
+    public postApiV2BackupListFolder(data: PostApiV2BackupListFolderData): Observable<PostApiV2BackupListFolderResponse> {
+        return __request(OpenAPI, this.http, {
+            method: 'POST',
+            url: '/api/v2/backup/list-folder',
+            body: data.requestBody,
+            mediaType: 'application/json'
+        });
+    }
+    
+    /**
+     * @param data The data for the request.
+     * @param data.requestBody
+     * @returns ListFileVersionsOutputDto Success
+     * @throws ApiError
+     */
+    public postApiV2BackupListVersions(data: PostApiV2BackupListVersionsData): Observable<PostApiV2BackupListVersionsResponse> {
+        return __request(OpenAPI, this.http, {
+            method: 'POST',
+            url: '/api/v2/backup/list-versions',
+            body: data.requestBody,
+            mediaType: 'application/json'
+        });
+    }
+    
+    /**
+     * @param data The data for the request.
+     * @param data.requestBody
+     * @returns SearchEntriesResponseDto Success
+     * @throws ApiError
+     */
+    public postApiV2BackupSearch(data: PostApiV2BackupSearchData): Observable<PostApiV2BackupSearchResponse> {
+        return __request(OpenAPI, this.http, {
+            method: 'POST',
+            url: '/api/v2/backup/search',
+            body: data.requestBody,
+            mediaType: 'application/json'
         });
     }
     

--- a/src/app/core/openapi/types.gen.ts
+++ b/src/app/core/openapi/types.gen.ts
@@ -87,7 +87,7 @@ export type DeleteBackupOutputDto = {
     ID?: (number) | null;
 };
 
-export type DuplicatiOperation = 'Backup' | 'Restore' | 'List' | 'Remove' | 'Repair' | 'RepairUpdate' | 'Verify' | 'Compact' | 'CreateReport' | 'ListRemote' | 'Delete' | 'Vacuum' | 'CustomRunner';
+export type DuplicatiOperation = 'Backup' | 'Restore' | 'List' | 'Remove' | 'Repair' | 'RepairUpdate' | 'Verify' | 'Compact' | 'CreateReport' | 'ListRemote' | 'Delete' | 'Vacuum' | 'CustomRunner' | 'ListFilesets' | 'ListFolderContents' | 'ListFileVersions' | 'SearchEntries';
 
 export type ExportArgsOnlyDto = {
     Backend?: (string) | null;
@@ -237,6 +237,9 @@ export type IRunnerData = {
         [key: string]: (string);
     } | null;
     readonly FilterStrings?: Array<(string)> | null;
+    readonly ExtraArguments?: Array<(string)> | null;
+    readonly PageSize?: number;
+    readonly PageOffset?: number;
     readonly TaskID?: number;
     readonly BackupID?: (string) | null;
     Operation?: DuplicatiOperation;
@@ -274,6 +277,75 @@ export type LicenseDto = {
     Url?: (string) | null;
     License?: (string) | null;
     Jsondata?: (string) | null;
+};
+
+export type ListFilesetsRequestDto = {
+    BackupId?: (string) | null;
+};
+
+export type ListFilesetsResponseDto = {
+    Success?: boolean;
+    Error?: (string) | null;
+    StatusCode?: (string) | null;
+    Data?: Array<ListFilesetsResponseItem> | null;
+    PageInfo?: PageInfo;
+};
+
+export type ListFilesetsResponseItem = {
+    Version?: number;
+    Time?: string;
+    IsFullBackup?: (boolean) | null;
+    FileCount?: (number) | null;
+    FileSizes?: (number) | null;
+};
+
+export type ListFileVersionsItemDto = {
+    Version?: number;
+    Time?: string;
+    Path?: (string) | null;
+    Size?: number;
+    IsDirectory?: boolean;
+    IsSymlink?: boolean;
+    LastModified?: string;
+};
+
+export type ListFileVersionsOutputDto = {
+    Success?: boolean;
+    Error?: (string) | null;
+    StatusCode?: (string) | null;
+    Data?: Array<ListFileVersionsItemDto> | null;
+    PageInfo?: PageInfo;
+};
+
+export type ListFileVersionsRequestDto = {
+    PageSize?: (number) | null;
+    Page?: (number) | null;
+    BackupId?: (string) | null;
+    Paths?: Array<(string)> | null;
+};
+
+export type ListFolderContentItemDto = {
+    Path?: (string) | null;
+    Size?: number;
+    IsDirectory?: boolean;
+    IsSymlink?: boolean;
+    LastModified?: string;
+};
+
+export type ListFolderContentRequestDto = {
+    PageSize?: (number) | null;
+    Page?: (number) | null;
+    BackupId?: (string) | null;
+    Paths?: Array<(string)> | null;
+    Time?: (string) | null;
+};
+
+export type ListFolderContentResponseDto = {
+    Success?: boolean;
+    Error?: (string) | null;
+    StatusCode?: (string) | null;
+    Data?: Array<ListFolderContentItemDto> | null;
+    PageInfo?: PageInfo;
 };
 
 export type LiveControlState = 'Running' | 'Paused';
@@ -319,6 +391,13 @@ export type NotificationDto = {
 };
 
 export type NotificationType = 'Information' | 'Warning' | 'Error';
+
+export type PageInfo = {
+    Page?: number;
+    PageSize?: number;
+    Total?: number;
+    Pages?: number;
+};
 
 export type RemoteControlStatusOutput = {
     CanEnable?: boolean;
@@ -369,6 +448,33 @@ export type ScheduleInputDto = {
     LastRun?: (string) | null;
     Rule?: (string) | null;
     AllowedDays?: Array<DayOfWeek> | null;
+};
+
+export type SearchEntriesItemDto = {
+    Version?: number;
+    Time?: string;
+    Path?: (string) | null;
+    Size?: number;
+    IsDirectory?: boolean;
+    IsSymlink?: boolean;
+    LastModified?: string;
+};
+
+export type SearchEntriesRequestDto = {
+    PageSize?: (number) | null;
+    Page?: (number) | null;
+    BackupId?: (string) | null;
+    Paths?: Array<(string)> | null;
+    Filters?: Array<(string)> | null;
+    Time?: (string) | null;
+};
+
+export type SearchEntriesResponseDto = {
+    Success?: boolean;
+    Error?: (string) | null;
+    StatusCode?: (string) | null;
+    Data?: Array<SearchEntriesItemDto> | null;
+    PageInfo?: PageInfo;
 };
 
 export type ServerStatusDto = {
@@ -469,6 +575,8 @@ export type SystemInfoDto = {
     SupportedLocales?: Array<LocaleDto> | null;
     BrowserLocaleSupported?: boolean;
     TimeZones?: Array<TimeZoneDto> | null;
+    APIExtensions?: Array<(string)> | null;
+    APIScopes?: Array<(string)> | null;
 };
 
 export type TaskStartedDto = {
@@ -991,6 +1099,30 @@ export type PostApiV1BackupByIdCopytotempData = {
 };
 
 export type PostApiV1BackupByIdCopytotempResponse = (CreateBackupDto);
+
+export type PostApiV2BackupListFilesetsData = {
+    requestBody: ListFilesetsRequestDto;
+};
+
+export type PostApiV2BackupListFilesetsResponse = (ListFilesetsResponseDto);
+
+export type PostApiV2BackupListFolderData = {
+    requestBody: ListFolderContentRequestDto;
+};
+
+export type PostApiV2BackupListFolderResponse = (ListFolderContentResponseDto);
+
+export type PostApiV2BackupListVersionsData = {
+    requestBody: ListFileVersionsRequestDto;
+};
+
+export type PostApiV2BackupListVersionsResponse = (ListFileVersionsOutputDto);
+
+export type PostApiV2BackupSearchData = {
+    requestBody: SearchEntriesRequestDto;
+};
+
+export type PostApiV2BackupSearchResponse = (SearchEntriesResponseDto);
 
 export type GetApiV1ProgressstateResponse = (IProgressEventData);
 

--- a/src/app/core/states/sysinfo.state.ts
+++ b/src/app/core/states/sysinfo.state.ts
@@ -66,6 +66,11 @@ export class SysinfoState {
     }, [] as FormView[]);
   });
 
+  hasV2ListOperations = computed(() => {
+    const apiExtensions = this.systemInfo()?.APIExtensions ?? [];
+    return apiExtensions.includes('v2:backup:list-filesets') && apiExtensions.includes('v2:backup:list-folder');
+  });
+
   preload(returnObservable = false): Observable<SystemInfoDto> | void {
     const obs = (this.#dupServer.getApiV1Systeminfo() as Observable<SystemInfoDto>).pipe(
       tap((systemInfo) => {

--- a/src/app/restore-flow/restore-flow.state.ts
+++ b/src/app/restore-flow/restore-flow.state.ts
@@ -2,16 +2,26 @@ import { inject, Injectable, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 import { finalize, forkJoin, retry, take } from 'rxjs';
-import { DuplicatiServerService, GetBackupResultDto, IListResultFileset } from '../core/openapi';
+import { DuplicatiServerService, GetBackupResultDto } from '../core/openapi';
+import { SysinfoState } from '../core/states/sysinfo.state';
 import { createRestoreOptionsForm } from './options/options.component';
 import { createEncryptionForm } from './restore-encryption/restore-encryption.component';
 import { createRestoreSelectFilesForm } from './select-files/select-files.component';
+
+type ListResultFileset = {
+    readonly Version: number;
+    readonly IsFullBackup?: boolean | undefined;
+    readonly Time: string;
+    readonly FileCount?: number | undefined;
+    readonly FileSizes?: number | undefined;
+};
 
 @Injectable({
   providedIn: 'root',
 })
 export class RestoreFlowState {
   #router = inject(Router);
+  #sysinfo = inject(SysinfoState);
   #dupServer = inject(DuplicatiServerService);
 
   backupId = signal<string | null>(null);
@@ -24,7 +34,7 @@ export class RestoreFlowState {
   selectFilesFormSignal = toSignal(this.selectFilesForm.valueChanges);
   selectOptionSignal = toSignal(this.selectFilesForm.controls.selectedOption.valueChanges);
   versionOptionsLoading = signal(false);
-  versionOptions = signal<IListResultFileset[]>([]);
+  versionOptions = signal<ListResultFileset[]>([]);
   isSubmitting = signal(false);
   isDraft = signal(false);
   isFileRestore = signal(false);
@@ -91,6 +101,42 @@ export class RestoreFlowState {
   getBackup(id: string, setFirstToForm = false) {
     this.versionOptionsLoading.set(true);
 
+    if (this.#sysinfo.hasV2ListOperations()) {
+      forkJoin([
+        this.#dupServer.getApiV1BackupById({
+          id,
+        }),
+        this.#dupServer
+        .postApiV2BackupListFilesets({
+          requestBody: {
+            BackupId: id
+          }
+        })
+        .pipe(retry(3))
+      ])
+        .pipe(
+          take(1),
+          finalize(() => this.versionOptionsLoading.set(false))
+        )
+        .subscribe({
+          next: ([backup, filesets]) => {
+            if (filesets.Error)
+              throw new Error(filesets.Error);
+
+            this.versionOptions.set((filesets.Data ?? [])
+            .map((x) => ({
+              Version: x.Version ?? -1,
+              IsFullBackup: x.IsFullBackup ?? undefined,
+              Time: x.Time ?? "<missing>",
+              FileCount: x.FileCount ?? undefined,
+              FileSizes: x.FileSizes ?? undefined,
+            })));
+            this.backup.set(backup);
+          },
+        });      
+    }
+    else
+    {
     forkJoin([
       this.#dupServer.getApiV1BackupById({
         id,
@@ -107,10 +153,20 @@ export class RestoreFlowState {
       )
       .subscribe({
         next: ([backup, filesets]) => {
-          this.versionOptions.set(filesets);
+          this.versionOptions.set(filesets.map((x) => ({
+            Version: x.Version ?? -1,
+            IsFullBackup: (x.IsFullBackup ?? 1) == 1,
+            Time: x.Time ?? "<missing>",
+            FileCount: x.FileCount ?? undefined,
+            FileSizes: x.FileSizes ?? undefined,
+          })));
           this.backup.set(backup);
         },
-      });
+      });      
+    }
+
+
+
   }
 
   #resetAllForms() {

--- a/src/app/restore-flow/select-files/select-files.component.ts
+++ b/src/app/restore-flow/select-files/select-files.component.ts
@@ -12,6 +12,7 @@ import { finalize, Subject, takeUntil } from 'rxjs';
 import FileTreeComponent, { BackupSettings } from '../../core/components/file-tree/file-tree.component';
 import { StatusBarState } from '../../core/components/status-bar/status-bar.state';
 import { DuplicatiServerService, GetApiV1BackupByIdFilesData } from '../../core/openapi';
+import { SysinfoState } from '../../core/states/sysinfo.state';
 import { RestoreFlowState } from '../restore-flow.state';
 
 const fb = new FormBuilder();
@@ -44,6 +45,7 @@ export const createRestoreSelectFilesForm = () => {
 export default class SelectFilesComponent {
   #dupServer = inject(DuplicatiServerService);
   #restoreFlowState = inject(RestoreFlowState);
+  #sysinfo = inject(SysinfoState);
   #router = inject(Router);
   #route = inject(ActivatedRoute);
   #datePipe = inject(DatePipe);
@@ -159,21 +161,58 @@ export default class SelectFilesComponent {
     if (this.isRepairing()) return;
 
     this.loadingRootPath.set(true);
-    this.#dupServer
-      .getApiV1BackupByIdFiles(params)
-      .pipe(
-        takeUntil(this.abortLoading$),
-        finalize(() => {
-          this.showFileTree.set(true);
-          this.loadingRootPath.set(false);
-        })
-      )
-      .subscribe({
-        next: (res) => {
-          const path = (res as any)['Files'][0].Path;
-          this.rootPath.set(path);
-        },
-      });
+    if (this.#sysinfo.hasV2ListOperations()) {
+      this.#dupServer
+        .postApiV2BackupListFolder({
+          requestBody: {
+            BackupId: backupSettings.id,
+            Time: backupSettings.time,
+            Paths: null,
+            PageSize: 10000,
+            Page: 0
+          }}
+        )
+        .pipe(
+          takeUntil(this.abortLoading$),
+          finalize(() => {
+            this.showFileTree.set(true);
+            this.loadingRootPath.set(false);
+          })
+        )
+        .subscribe({
+          next: (res) => {
+            if (res.Error)
+              throw new Error(res.Error);
+            
+          // TODO: Handle folders larger than 10000
+            const paths = (res.Data ?? []).map((x) => x.Path);
+            if (paths.length == 1)
+              this.rootPath.set(paths[0] ?? '/');
+            else
+              this.rootPath.set(''); // Handle multiple roots by treating the root as empty
+          },
+        });
+
+    } else {
+      this.#dupServer
+        .getApiV1BackupByIdFiles(params)
+        .pipe(
+          takeUntil(this.abortLoading$),
+          finalize(() => {
+            this.showFileTree.set(true);
+            this.loadingRootPath.set(false);
+          })
+        )
+        .subscribe({
+          next: (res) => {
+            const paths = ((res as any)['Files'] as any[]).map((x) => x.Path);
+            if (paths.length == 1)
+              this.rootPath.set(paths[0] ?? '/');
+            else
+              this.rootPath.set(''); // Handle multiple roots by treating the root as empty
+          },
+        });
+    }
   }
 
   abortLoading$ = new Subject();

--- a/src/app/restore-flow/select-files/select-files.component.ts
+++ b/src/app/restore-flow/select-files/select-files.component.ts
@@ -168,7 +168,7 @@ export default class SelectFilesComponent {
             BackupId: backupSettings.id,
             Time: backupSettings.time,
             Paths: null,
-            PageSize: 10000,
+            PageSize: 0, // TODO: Add pagination support
             Page: 0
           }}
         )
@@ -183,8 +183,7 @@ export default class SelectFilesComponent {
           next: (res) => {
             if (res.Error)
               throw new Error(res.Error);
-            
-          // TODO: Handle folders larger than 10000
+
             const paths = (res.Data ?? []).map((x) => x.Path);
             if (paths.length == 1)
               this.rootPath.set(paths[0] ?? '/');

--- a/src/app/restore-flow/select-files/select-files.component.ts
+++ b/src/app/restore-flow/select-files/select-files.component.ts
@@ -181,9 +181,6 @@ export default class SelectFilesComponent {
         )
         .subscribe({
           next: (res) => {
-            if (!res.Success)
-              throw new Error(res.Error ?? 'Unknown error');
-
             const paths = (res.Data ?? []).map((x) => x.Path);
             if (paths.length == 1)
               this.rootPath.set(paths[0] ?? '/');

--- a/src/app/restore-flow/select-files/select-files.component.ts
+++ b/src/app/restore-flow/select-files/select-files.component.ts
@@ -63,6 +63,7 @@ export default class SelectFilesComponent {
   rootPath = signal<string | undefined>(undefined);
   loadingRootPath = signal(false);
   isRepairing = signal(false);
+  requestedRootPathLoadId = signal<string | null>(null);
 
   loadingEffect = effect(() => {
     const versionOptionsLoading = this.versionOptionsLoading();
@@ -97,14 +98,17 @@ export default class SelectFilesComponent {
 
     this.showFileTree.set(false);
 
-    queueMicrotask(() => {
-      const settings = {
-        id: id + '',
-        time,
-      } as BackupSettings;
-      this.backupSettings.set(settings);
-      this.getRootPath(settings);
-    });
+    if (this.requestedRootPathLoadId() !== id + '') {
+      this.requestedRootPathLoadId.set(id + '');
+      queueMicrotask(() => {
+        const settings = {
+          id: id + '',
+          time,
+        } as BackupSettings;
+        this.backupSettings.set(settings);
+        this.getRootPath(settings);
+      });
+    }
   });
 
   repairEffect = effect(() => {

--- a/src/app/restore-flow/select-files/select-files.component.ts
+++ b/src/app/restore-flow/select-files/select-files.component.ts
@@ -181,8 +181,8 @@ export default class SelectFilesComponent {
         )
         .subscribe({
           next: (res) => {
-            if (res.Error)
-              throw new Error(res.Error);
+            if (!res.Success)
+              throw new Error(res.Error ?? 'Unknown error');
 
             const paths = (res.Data ?? []).map((x) => x.Path);
             if (paths.length == 1)


### PR DESCRIPTION
This updates the restore flow to use the new faster list operations.

This also uses the newly added extension flags to support fallback in case the server does not support it.

Fallback for cases with multiple root paths is not fully tested.
Pagination is not implemented, so large folder listings may cause timeouts.