### PR TITLE
Follow server backends

### DIFF
--- a/src/app/backup/backup.state.ts
+++ b/src/app/backup/backup.state.ts
@@ -77,8 +77,6 @@ export class BackupState {
   generalFormSignal = toSignal(this.generalForm.valueChanges);
   encryptionFieldSignal = toSignal(this.generalForm.controls.encryption.valueChanges);
 
-  destinationOptions = computed(() => this.#sysinfo.backendModules() ?? []);
-
   advancedOptions = computed(() => {
     return this.#sysinfo.systemInfo()?.Options?.map(this.#mapCommandLineArgumentsToFormViews) ?? [];
   });

--- a/src/app/backup/destination/destination.component.ts
+++ b/src/app/backup/destination/destination.component.ts
@@ -22,8 +22,8 @@ import { finalize } from 'rxjs';
 import { ConfirmDialogComponent } from '../../core/components/confirm-dialog/confirm-dialog.component';
 import { IDynamicModule } from '../../core/openapi';
 import { TestDestinationService } from '../../core/services/test-destination.service';
+import { DestinationConfigState } from '../../core/states/destinationconfig.state';
 import { BackupState } from '../backup.state';
-import { DESTINATION_CONFIG } from './destination.config';
 import { FormView } from './destination.config-utilities';
 import { SingleDestinationComponent } from './single-destination/single-destination.component';
 
@@ -89,6 +89,7 @@ export default class DestinationComponent {
   #router = inject(Router);
   #route = inject(ActivatedRoute);
   #backupState = inject(BackupState);
+  #destinationState = inject(DestinationConfigState);
   #dialog = inject(SparkleDialogService);
   #testDestination = inject(TestDestinationService);
   injector = inject(Injector);
@@ -104,14 +105,8 @@ export default class DestinationComponent {
   successfulTest = signal(false);
   testLoading = signal(false);
   destinationTypeOptionsInFocus = signal(['file', 'ssh', 's3', 'gcs', 'googledrive', 'azure']);
-  destinationTypeOptions = signal(
-    DESTINATION_CONFIG.map((x) => ({
-      key: x.customKey ?? x.key,
-      customKey: x.customKey ?? null,
-      displayName: x.displayName,
-      description: x.description,
-    }))
-  );
+  destinationTypeOptions = this.#destinationState.destinationTypeOptions;
+
   destinationTypeOptionsFocused = computed(() => {
     const focused = this.destinationTypeOptionsInFocus();
     const options = this.destinationTypeOptions();

--- a/src/app/backup/destination/destination.config-utilities.ts
+++ b/src/app/backup/destination/destination.config-utilities.ts
@@ -3,7 +3,7 @@ import { FormControl, FormGroup } from '@angular/forms';
 import { ArgumentType, ICommandLineArgument } from '../../core/openapi';
 import { WebModuleOption } from '../../core/services/webmodules.service';
 import { DestinationFormGroupValue } from './destination.component';
-import { DESTINATION_CONFIG } from './destination.config';
+import { DESTINATION_CONFIG, DESTINATION_CONFIG_DEFAULT } from './destination.config';
 
 export type ValueOfDestinationFormGroup = DestinationFormGroup['value'];
 export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
@@ -70,10 +70,21 @@ export function addPath(path: string | null | undefined) {
   return path.startsWith('/') ? path : '/' + path;
 }
 
+export function getConfigurationByKey(key: string): DestinationConfigEntry {
+  const config = DESTINATION_CONFIG.find((x) => x.key === key || x.customKey === key);
+  return (
+    config ?? {
+      key: key,
+      displayName: key,
+      ...DESTINATION_CONFIG_DEFAULT,
+    }
+  );
+}
+
 export function fromSearchParams(destinationType: string, urlObj: URL) {
   const advanced: { [key: string]: any } = {};
   const dynamic: { [key: string]: any } = {};
-  const config = DESTINATION_CONFIG.find((x) => x.key === destinationType);
+  const config = getConfigurationByKey(destinationType);
 
   urlObj.searchParams.forEach((value, key) => {
     const isDynamic = config?.dynamicFields?.some((x) => x === key || (<any>x)?.name === key);
@@ -103,15 +114,8 @@ export function toSearchParams(arr: [string, string | number | unknown][], witho
 }
 
 export function toTargetPath(fields: DestinationFormGroupValue): string {
-  const destinationType = fields.destinationType;
-  const destinationConfig = DESTINATION_CONFIG.find(
-    (x) => x.customKey === destinationType || x.key === destinationType
-  );
-
-  if (!destinationConfig) {
-    throw new Error('Invalid destination type');
-  }
-
+  const destinationType = fields.destinationType ?? '';
+  const destinationConfig = getConfigurationByKey(destinationType);
   return destinationConfig?.mapper.to(fields) ?? '';
 }
 
@@ -125,7 +129,7 @@ export function fromTargetPath(targetPath: string) {
 
   // Only local files allow the shortcut file paths like file://%MUSIC%/music.mp3 to music folder
   if (path.startsWith('%') && destinationType === 'file') {
-    return DESTINATION_CONFIG.find((x) => x.customKey === destinationType || x.key === destinationType)?.mapper.from(
+    return getConfigurationByKey(destinationType).mapper.from(
       destinationType,
       new URL('http://localhost'),
       targetPath
@@ -146,7 +150,7 @@ export function fromTargetPath(targetPath: string) {
 
     if (hostAsNumber && !hostAsIpAddress) return null;
 
-    return DESTINATION_CONFIG.find((x) => x.customKey === destinationType || x.key === destinationType)?.mapper.from(
+    return getConfigurationByKey(destinationType).mapper.from(
       destinationType,
       urlObj,
       targetPath
@@ -155,10 +159,4 @@ export function fromTargetPath(targetPath: string) {
     // console.error('Error while parsing target path', error);
     return null;
   }
-
-  if (!canParse) {
-    throw new Error('Invalid target path');
-  }
-
-  return null;
 }

--- a/src/app/backup/destination/single-destination/single-destination.component.ts
+++ b/src/app/backup/destination/single-destination/single-destination.component.ts
@@ -17,9 +17,14 @@ import FileTreeComponent from '../../../core/components/file-tree/file-tree.comp
 import { SizeComponent } from '../../../core/components/size/size.component';
 import { TimespanComponent } from '../../../core/components/timespan/timespan.component';
 import { ArgumentType, ICommandLineArgument } from '../../../core/openapi';
-import { BackupState } from '../../backup.state';
-import { DESTINATION_CONFIG } from '../destination.config';
-import { CustomFormView, FormView, fromTargetPath, toTargetPath } from '../destination.config-utilities';
+import { DestinationConfigState } from '../../../core/states/destinationconfig.state';
+import {
+  CustomFormView,
+  FormView,
+  fromTargetPath,
+  getConfigurationByKey,
+  toTargetPath,
+} from '../destination.config-utilities';
 
 type DestinationConfig = {
   destinationType: string;
@@ -55,7 +60,7 @@ type DestinationConfig = {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SingleDestinationComponent {
-  #backupState = inject(BackupState);
+  #destinationState = inject(DestinationConfigState);
   injector = inject(Injector);
   targetUrl = model.required<string | null>();
 
@@ -94,11 +99,16 @@ export class SingleDestinationComponent {
   });
 
   destinationTypeEffect = effect(() => {
-    const key = this.destinationType();
+    const key = this.destinationType() ?? '';
 
-    const destinationConfig = DESTINATION_CONFIG.find((x) => x.customKey === key || x.key === key);
+    const destinationConfig = getConfigurationByKey(key);
     const _key = destinationConfig?.key;
-    const item = this.#backupState.destinationOptions().find((x) => x.Key === _key);
+    const item = this.#destinationState.backendModules().find((x) => x.Key === _key) ?? {
+      Key: key,
+      DisplayName: key,
+      Description: getConfigurationByKey(key).description,
+      Options: [],
+    };
 
     if (!item || !item.Options || !key) return;
 
@@ -259,14 +269,14 @@ export class SingleDestinationComponent {
     return formView;
   }
 
-    getDefaultFormView(optionName: string) {
-      return {
-        name: optionName,
-        type: 'String',
-        shortDescription: optionName,
-        longDescription: $localize`This is an undocumented option.`,
-      };
-    }
+  getDefaultFormView(optionName: string) {
+    return {
+      name: optionName,
+      type: 'String',
+      shortDescription: optionName,
+      longDescription: $localize`This is an undocumented option.`,
+    };
+  }
 
   getFieldGroup(form: any, fieldGroup: string) {
     return form[fieldGroup];

--- a/src/app/core/states/destinationconfig.state.ts
+++ b/src/app/core/states/destinationconfig.state.ts
@@ -1,0 +1,29 @@
+import { computed, inject, Injectable } from '@angular/core';
+import { getConfigurationByKey } from '../../backup/destination/destination.config-utilities';
+import { SysinfoState } from './sysinfo.state';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DestinationConfigState {
+  #sysinfo = inject(SysinfoState);
+
+  supportedDestinationTypes = computed(() =>
+    this.#sysinfo
+      .backendModules()
+      .map((x) => x.Key!)
+      .filter((x) => x)
+      .map((key) => getConfigurationByKey(key))
+  );
+
+  destinationTypeOptions = computed(() =>
+    this.supportedDestinationTypes().map((x) => ({
+      key: x.customKey ?? x.key,
+      customKey: x.customKey ?? null,
+      displayName: x.displayName,
+      description: x.description,
+    }))
+  );
+
+  backendModules = computed(() => this.#sysinfo.backendModules() ?? []);
+}

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -14,7 +14,8 @@ import {
   SparkleTableComponent,
 } from '@sparkle-ui/core';
 import { finalize } from 'rxjs';
-import { DESTINATION_CONFIG, S3_HOST_SUFFIX_MAP } from '../backup/destination/destination.config';
+import { S3_HOST_SUFFIX_MAP } from '../backup/destination/destination.config';
+import { getConfigurationByKey } from '../backup/destination/destination.config-utilities';
 import StatusBarComponent from '../core/components/status-bar/status-bar.component';
 import { StatusBarState } from '../core/components/status-bar/status-bar.state';
 import { localStorageSignal } from '../core/functions/localstorage-signal';
@@ -94,19 +95,15 @@ export default class HomeComponent {
   getBackendIcon(targetUrl: string | null | undefined) {
     if (!targetUrl) return '';
     const backend = targetUrl.split('://')[0];
-    const match = DESTINATION_CONFIG.find((x) => x.key === backend);
-    if (!match) return 'database';
-
+    const match = getConfigurationByKey(backend);
     const override = DestinationOverrides[match.key];
-    if (override?.Icon) return override.Icon;
-
-    return 'database';
+    return override?.Icon ?? 'database';
   }
 
   getBackendType(targetUrl: string | null | undefined) {
     if (!targetUrl) return '';
     const backend = targetUrl.split('://')[0];
-    const match = DESTINATION_CONFIG.find((x) => x.key === backend);
+    const match = getConfigurationByKey(backend);
     if (!match) return '';
 
     const override = DestinationOverrides[match.key];

--- a/src/app/restore-flow/restore-destination/restore-destination.component.ts
+++ b/src/app/restore-flow/restore-destination/restore-destination.component.ts
@@ -21,11 +21,11 @@ import {
 } from '@sparkle-ui/core';
 import { finalize } from 'rxjs';
 import { BackupState } from '../../backup/backup.state';
-import { DESTINATION_CONFIG } from '../../backup/destination/destination.config';
 import { SingleDestinationComponent } from '../../backup/destination/single-destination/single-destination.component';
 import { ConfirmDialogComponent } from '../../core/components/confirm-dialog/confirm-dialog.component';
 import { IDynamicModule } from '../../core/openapi';
 import { TestDestinationService } from '../../core/services/test-destination.service';
+import { DestinationConfigState } from '../../core/states/destinationconfig.state';
 import { RestoreFlowState } from '../restore-flow.state';
 
 @Component({
@@ -53,6 +53,7 @@ export default class RestoreDestinationComponent {
   #testDestination = inject(TestDestinationService);
   injector = inject(Injector);
   #restoreFlowState = inject(RestoreFlowState);
+  #destinationState = inject(DestinationConfigState);
 
   formRef = viewChild.required<ElementRef<HTMLFormElement>>('formRef');
 
@@ -72,14 +73,7 @@ export default class RestoreDestinationComponent {
   successfulTest = signal(false);
   testLoading = signal(false);
   destinationTypeOptionsInFocus = signal(['file', 'ssh', 's3', 'gcs', 'googledrive', 'azure']);
-  destinationTypeOptions = signal(
-    DESTINATION_CONFIG.map((x) => ({
-      key: x.customKey ?? x.key,
-      customKey: x.customKey ?? null,
-      displayName: x.displayName,
-      description: x.description,
-    }))
-  );
+  destinationTypeOptions = this.#destinationState.destinationTypeOptions;
   destinationTypeOptionsFocused = computed(() => {
     const focused = this.destinationTypeOptionsInFocus();
     const options = this.destinationTypeOptions();


### PR DESCRIPTION
This PR makes the destinations reported in the UI follow the backends offered by the server.

This change supports cases where there is a mismatch between the FE/BE in terms of supported backends and available configurations.

If the user provides a non-existing backend in the target url, this is now mapped to a default configuration, so it can at least be shown. The edit capabilities are not great, but at least there is something.

In the case where there exists a UI configuration for a backend that is not supported by the backend, this backend is not offered by the UI, but can be accessed if the target url points to it.

This fixes #271
This fixes #272