### PR TITLE
Added locales to loading list

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -152,11 +152,6 @@
                 "output": "./locale/dayjs/"
               },
               {
-                "glob": "**/{en-US,en-GB,cs,da,de,es,fi,fr,hu,it,ja,nl,pl,pt-BR,pt,ru,sr,sv,zh-Hans,zh-Hant}.mjs",
-                "input": "./node_modules/@angular/common/locales",
-                "output": "./locale/angular/"
-              },
-              {
                 "glob": "**/*",
                 "input": "./node_modules/@sparkle-ui/core/assets",
                 "output": "./sparkle-ui-assets/"

--- a/src/app/core/locales/locales.utility.ts
+++ b/src/app/core/locales/locales.utility.ts
@@ -1,11 +1,49 @@
 import { registerLocaleData } from '@angular/common';
 import { loadTranslations } from '@angular/localize';
 
+// Locale data imports (manually curated for LANGUAGES list)
+import localeCs from '@angular/common/locales/cs';
+import localeDa from '@angular/common/locales/da';
+import localeDe from '@angular/common/locales/de';
+import localeEs from '@angular/common/locales/es';
+import localeFi from '@angular/common/locales/fi';
+import localeFr from '@angular/common/locales/fr';
+import localeHu from '@angular/common/locales/hu';
+import localeIt from '@angular/common/locales/it';
+import localeJa from '@angular/common/locales/ja';
+import localeNl from '@angular/common/locales/nl';
+import localePl from '@angular/common/locales/pl';
+import localePt from '@angular/common/locales/pt';
+import localeRu from '@angular/common/locales/ru';
+import localeSr from '@angular/common/locales/sr';
+import localeSv from '@angular/common/locales/sv';
+import localeZhHans from '@angular/common/locales/zh-Hans';
+import localeZhHant from '@angular/common/locales/zh-Hant';
+
+// Mapping locale codes to their imported Angular locale data
+const ANGULAR_LOCALE_DATA: Record<string, any> = {
+  'nl': localeNl,
+  'fr': localeFr,
+  'de': localeDe,
+  'cs': localeCs,
+  'da': localeDa,
+  'es': localeEs,
+  'fi': localeFi,
+  'hu': localeHu,
+  'it': localeIt,
+  'ja': localeJa,
+  'pl': localePl,
+  'pt': localePt,
+  'pt-BR': localePt,
+  'ru': localeRu,
+  'sr': localeSr,
+  'sv': localeSv,
+  'zh-Hans': localeZhHans,
+  'zh-Hant': localeZhHant,
+};
+
 export const DEFAULT_LOCALE = 'en-US';
 
-// This is the list of supported languages for the UI
-// It is used to populate the language selector in the settings
-// and to determine which translations to load
 export const LANGUAGES = [
   { value: 'en', label: 'English (en-US)' },
   { value: 'en-GB', label: 'English (en-GB)' },
@@ -113,7 +151,6 @@ const LOCALE_MAP: Record<string, string> = {
   'zh-HK': 'zh-TW',
 };
 
-// Angular mjs locales are slightly different from the Transifex locales
 export const ANGULAR_MJS_LOCALE_MAP: Record<string, string> = {
   'ja-JP': 'ja',
   'nl-NL': 'nl',
@@ -129,7 +166,7 @@ type Locales = (typeof SUPPORTED_LOCALES)[number];
 export function mapLocale(locale: string | null | undefined) {
   if (!locale) return 'en';
 
-  return (LOCALE_MAP as { [key: string]: string })[locale] ?? 'en';
+  return LOCALE_MAP[locale] ?? 'en';
 }
 
 export function getLocale(): Locales {
@@ -141,16 +178,17 @@ export function getLocale(): Locales {
     ?? LOCALE_MAP[locale.split('-')[0]] // Map unknown specific locales to base language
     ?? DEFAULT_LOCALE;
 
-  if (locale === DEFAULT_LOCALE) return locale;
+    if (locale === DEFAULT_LOCALE) return locale;
 
-  // Angular mjs locales are different from the standard locales
-  const mjsLocale = ANGULAR_MJS_LOCALE_MAP[mappedLocale] ?? mappedLocale;
-  import(/* @vite-ignore */ `locale/angular/${mjsLocale}.mjs`).then((m) =>
-    registerLocaleData(m.default)
-  );
+    // Angular mjs locales are different from the standard locales
+    const mjsLocale = ANGULAR_MJS_LOCALE_MAP[mappedLocale] ?? mappedLocale;
+    const localeData = ANGULAR_LOCALE_DATA[mjsLocale];
+    if (localeData)
+      registerLocaleData(localeData);
+  
 
-  // Until we have a proper translation system, we need to load the message translations manually
-  var mappedFileLocale = mappedLocale.replace(/-/g, '_');
+  // We need to load the message translations manually, as Angular only supports static translations
+  const mappedFileLocale = mappedLocale.replace(/-/g, '_');
   const tempLocale = locale === 'en' ? '' : '.' + mappedFileLocale;
 
   fetch(`locale/messages${tempLocale}.json`)


### PR DESCRIPTION
The `.mjs` files were not loading correctly.
This update manually loads the locales so the source analyzer can figure out what is being used.