### PR TITLE
Fix loosing None encryption option

### DIFF
--- a/src/app/backup/backup.state.ts
+++ b/src/app/backup/backup.state.ts
@@ -406,7 +406,7 @@ export class BackupState {
       },
     ];
 
-    if (generalFormValue.encryption !== '') {
+    if (generalFormValue.encryption !== '' && generalFormValue.encryption !== NONE_OPTION.Key) {
       encryption = [
         {
           Name: 'encryption-module',

--- a/src/app/backup/general/general.component.html
+++ b/src/app/backup/general/general.component.html
@@ -42,7 +42,7 @@
       </ng-template>
     </spk-select>
 
-    @if (encryptionFieldSignal() !== '') {
+    @if (encryptionFieldSignal() !== noneOptionKey) {
       <div class="passwords">
         <spk-form-field>
           <label for="password" i18n>
@@ -129,7 +129,7 @@
       Exit
     </button>
 
-    @if (encryptionFieldSignal() === '' || !isNew()) {
+    @if (encryptionFieldSignal() === noneOptionKey || !isNew()) {
       <button spk-button class="raised primary" type="submit" [disabled]="nameAndDescriptionValid() === false" i18n>
         Continue
         <spk-icon>arrow-right</spk-icon>

--- a/src/app/backup/general/general.component.ts
+++ b/src/app/backup/general/general.component.ts
@@ -19,7 +19,6 @@ import {
   SparkleSelectComponent,
   SparkleTooltipDirective,
 } from '@sparkle-ui/core';
-import { IDynamicModule } from '../../core/openapi';
 import { PasswordGeneratorService } from '../../core/services/password-generator.service';
 import { SysinfoState } from '../../core/states/sysinfo.state';
 import { validateWhen, watchField } from '../../core/validators/custom.validators';
@@ -52,7 +51,7 @@ export const createGeneralForm = (
 };
 
 export const NONE_OPTION = {
-  Key: '',
+  Key: '-',
   DisplayName: 'None',
 };
 
@@ -90,11 +89,12 @@ export default class GeneralComponent {
   showPassword = signal(false);
   copiedPassword = signal(false);
   showCopyPassword = signal(false);
+  noneOptionKey = NONE_OPTION.Key;
 
   encryptionEffect = effect(() => {
     const encryptionField = this.encryptionFieldSignal();
 
-    if (encryptionField === '') {
+    if (encryptionField === NONE_OPTION.Key) {
       this.copiedPassword.set(false);
       this.showCopyPassword.set(false);
     }
@@ -147,20 +147,6 @@ export default class GeneralComponent {
         console.error('Failed to copy text: ', err);
       }
     }
-  }
-
-  displayFn() {
-    const encryptionOptions = this.#sysinfo.systemInfo()?.EncryptionModules ?? [];
-
-    return (val: IDynamicModule['Key']) => {
-      const item = [NONE_OPTION, ...encryptionOptions].find((x) => x.Key === val);
-
-      if (!item) {
-        return '';
-      }
-
-      return `${item.DisplayName}`;
-    };
   }
 
   generatePassword() {


### PR DESCRIPTION
The issue is that the select entry treats an empty key as "not selected".

This PR changes the key to `-`, so the select retains the state.

This fixes #240