### PR TITLE
Rework path handling

### DIFF
--- a/src/app/backup/destination/single-destination/single-destination.component.html
+++ b/src/app/backup/destination/single-destination/single-destination.component.html
@@ -84,7 +84,7 @@
       @let labelContent = item.formView.shortDescription ?? item.formView.name;
       @let formInput = getFieldGroup(form, item.fieldGroup)[item.formView.name];
       @let fieldValue = getFieldValue(item.fieldGroup, item.formView.name);
-      @let isFieldEmpty = (fieldValue ?? '').trim() === '';
+      @let isFieldEmpty = (fieldValue ?? '').toString().trim() === '';
       @let formFieldId =
         'destination-' + item.fieldGroup + '-' + item.index + '-' + (item.asHttpOptions ? 'http' : 'other');
 
@@ -128,7 +128,13 @@
             [ngModel]="formInput"
             (ngModelChange)="updateFieldValue(item.fieldGroup, item.formView.name, $event)" />
         </app-file-tree>
-      } @else if (item.formView.type === 'String' || item.formView.type === 'Path' || item.formView.type === 'Email') {
+      } @else if (
+        item.formView.type === 'String' ||
+        item.formView.type === 'Path' ||
+        item.formView.type === 'Email' ||
+        item.formView.type === 'Hostname' ||
+        item.formView.type === 'Bucketname'
+      ) {
         <spk-form-field>
           <label [for]="formFieldId">
             {{ labelContent }}
@@ -138,9 +144,17 @@
             @if (isFieldEmpty && item.formView.type === 'Path') {
               <spk-icon
                 class="warn"
-                [spkTooltip]="'An empty path means storing data in the root folder, which is not recommended'">
+                [spkTooltip]="
+                  'An empty path means storing data in the initial or root folder, which is not recommended'
+                ">
                 warning
               </spk-icon>
+            }
+            @if (item.formView.type == 'Hostname' && !isFieldEmpty && !isValidHostname(fieldValue)) {
+              <spk-icon class="error" [spkTooltip]="'Hostname is invalid'">x-circle</spk-icon>
+            }
+            @if (item.formView.type == 'Bucketname' && !isFieldEmpty && !isValidBucketname(fieldValue)) {
+              <spk-icon class="warn" [spkTooltip]="'Bucket name is invalid'">warning</spk-icon>
             }
             @if (item.formView.isMandatory && isFieldEmpty) {
               <spk-icon class="error" [spkTooltip]="'This field is mandatory'">asterisk</spk-icon>
@@ -151,10 +165,11 @@
             [type]="item.formView.type === 'Email' ? 'email' : 'text'"
             [id]="formFieldId"
             [ngModel]="formInput"
+            (keydown)="onKeyDown(item.fieldGroup, item.formView.name, item.formView.type, $event)"
             (ngModelChange)="updateFieldValue(item.fieldGroup, item.formView.name, $event)" />
 
           @let inputValue = fieldValue;
-          @let hasLeadingSlashes = hasDoubleLeadingSlashes(inputValue ?? '');
+          @let hasLeadingSlashes = hasLeadingSlash(inputValue ?? '');
           @let leadingSlashesMessage = hasLeadingSlashes && item.formView.doubleSlash?.message;
           @let slashType = item.formView.doubleSlash?.type;
 
@@ -168,6 +183,10 @@
             </spk-icon>
           } @else if (item.formView.type === 'Email') {
             <spk-icon prefix>envelope</spk-icon>
+          } @else if (item.formView.type === 'Hostname') {
+            <spk-icon prefix>hard-drives</spk-icon>
+          } @else if (item.formView.type === 'Bucketname') {
+            <spk-icon prefix>jar</spk-icon>
           } @else {
             <spk-icon prefix>textbox</spk-icon>
           }

--- a/src/app/backup/destination/single-destination/single-destination.component.ts
+++ b/src/app/backup/destination/single-destination/single-destination.component.ts
@@ -283,8 +283,8 @@ export class SingleDestinationComponent {
     return form[fieldGroup];
   }
 
-  hasDoubleLeadingSlashes(str?: string | null) {
-    return str?.startsWith('//') ?? false;
+  hasLeadingSlash(str?: string | null) {
+    return str?.startsWith('/') ?? false;
   }
 
   addAdvancedOption(formView: FormView) {
@@ -293,6 +293,61 @@ export class SingleDestinationComponent {
     form.advanced[formView.name] = formView.defaultValue;
 
     this.destinationForm.set({ ...form });
+  }
+
+  isValidBucketname(name: string): boolean {
+    if (!name) return false;
+  
+    const length = name.length;
+  
+    // Length between 3 and 63 characters
+    if (length < 3 || length > 63) return false;
+  
+    // Must be lowercase letters, numbers, dots, or hyphens
+    if (!/^[a-z0-9.-]+$/.test(name)) return false;
+  
+    // Must start and end with a letter or number
+    if (!/^[a-z0-9]/.test(name) || !/[a-z0-9]$/.test(name)) return false;
+  
+    // Cannot be formatted like an IP address
+    if (/^\d{1,3}(\.\d{1,3}){3}$/.test(name)) return false;
+  
+    // Cannot contain adjacent periods or dashes next to periods
+    if (/(\.\.)|(\.-)|(-\.)/.test(name)) return false;
+  
+    return true;
+  }
+
+  isValidHostname(hostname: string): boolean {
+    if (!hostname || hostname.length > 253) return false;
+  
+    const labels = hostname.split('.');
+  
+    for (const label of labels) {
+      // Each label must be 1–63 characters
+      if (!label || label.length > 63) return false;
+  
+      // Must start and end with alphanumeric characters
+      if (!/^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$/.test(label)) {
+        return false;
+      }
+    }
+  
+    return true;
+  }
+
+  onKeyDown(fieldGroup: 'custom' | 'dynamic' | 'advanced', fieldName: string, type: FormView['type'], event: KeyboardEvent) {
+    if (type === 'Hostname' || type === 'Bucketname') {
+      const controlKeys = [
+        'Backspace', 'Delete', 'ArrowLeft', 'ArrowRight',
+        'Tab', 'Home', 'End'
+      ];
+      if (controlKeys.includes(event.key)) return;
+      if (event.key == '/' || event.key == '\\' || event.key == ':') {
+        event.preventDefault();
+        return;
+      }
+    }
   }
 
   updateFieldValue(fieldGroup: 'custom' | 'dynamic' | 'advanced', fieldName: string, newValue: any) {

--- a/src/app/core/components/file-tree/file-tree.component.ts
+++ b/src/app/core/components/file-tree/file-tree.component.ts
@@ -307,9 +307,8 @@ export default class FileTreeComponent {
       const x = pathPart.slice(1);
       const dir = pathPart.startsWith('-') ? 'exclude' : 'include';
       const pathDelimiter = this.pathDelimiter();
-      const pathToTest = isWindows ? x.slice(2) : x;
 
-      if (pathToTest.startsWith(pathDelimiter) && x.endsWith(pathDelimiter)) {
+      if (x.endsWith(pathDelimiter)) {
         // Works - Folder
         if (nodeType !== 'folder') continue;
         const res = nodeId === x;

--- a/src/app/core/components/file-tree/file-tree.component.ts
+++ b/src/app/core/components/file-tree/file-tree.component.ts
@@ -174,13 +174,15 @@ export default class FileTreeComponent {
 
     if (rootPaths.length > 0) {
       roots = rootPaths.map((rootPath) => {
+        const evalState = this.#eval(currentPaths, rootPath, 'folder', null);        
+
         return {
           id: rootPath,
           resolvedpath: rootPath,
           text: rootPath,
           parentPath: '',
           children: [],
-          evalState: TreeEvalEnum.None,
+          evalState: evalState,
           isIndeterminate: false,
           cls: 'folder',
         };
@@ -190,7 +192,7 @@ export default class FileTreeComponent {
         {
           id: ROOTPATH,
           resolvedpath: ROOTPATH,
-          text: 'Computer',
+          text: $localize`Computer`,
           parentPath: '',
           children: [],
           evalState: TreeEvalEnum.None,

--- a/src/app/restore-flow/select-files/select-files.component.html
+++ b/src/app/restore-flow/select-files/select-files.component.html
@@ -30,6 +30,7 @@
       <!-- <pre>{{ rootPaths() }}</pre> -->
       <app-file-tree
         [rootPaths]="rootPaths()"
+        [initialNodes]="initialNodes()"
         [backupSettings]="backupSettings()"
         [multiSelect]="true"
         [showFiles]="true">

--- a/src/app/restore-flow/select-files/select-files.component.ts
+++ b/src/app/restore-flow/select-files/select-files.component.ts
@@ -10,7 +10,7 @@ import {
 } from '@sparkle-ui/core';
 import { finalize, Subject, takeUntil } from 'rxjs';
 import FileTreeComponent, { BackupSettings } from '../../core/components/file-tree/file-tree.component';
-import { DuplicatiServerService, GetApiV1BackupByIdFilesData } from '../../core/openapi';
+import { DuplicatiServerService, GetApiV1BackupByIdFilesData, TreeNodeDto } from '../../core/openapi';
 import { BytesPipe } from '../../core/pipes/byte.pipe';
 import { SysinfoState } from '../../core/states/sysinfo.state';
 import { RestoreFlowState } from '../restore-flow.state';
@@ -66,6 +66,7 @@ export default class SelectFilesComponent {
   showFileTree = signal<boolean>(false);
   backupSettings = signal<BackupSettings | null>(null);
   rootPaths = signal<string[]>([]);
+  initialNodes = signal<TreeNodeDto[]>([]);
   loadingRootPath = signal(false);
   isRepairing = signal(false);
   loadedVersions = signal<{[key: string]: boolean }>({});
@@ -199,9 +200,30 @@ export default class SelectFilesComponent {
         .subscribe({
           next: (res) => {
             const paths = (res.Data ?? []).map((x) => x.Path ?? '');
-            if (paths.length > 0) {
-              this.rootPaths.set(paths);
+            if (paths.length > 0) {     
+
+              // The roots may include more than absolute root paths, so we need to split them
+              // into roots and descendants to avoid showing too many root nodes in the tree.
+              const { roots, descendants } = this.splitRootsAndDescendants(paths);
+              this.initialNodes.set(descendants.map((path) => {
+                const label = path.replace(/[\\/]+$/, '') // strip trailing slash
+                  .split(/[\\/]/)
+                  .filter(Boolean)
+                  .pop() || path;
+
+                const node: TreeNodeDto = {
+                  id: path,
+                  leaf: false,
+                  cls: 'folder',
+                  text: label,
+                  iconCls: 'folder',
+                  fileSize: -1
+                };
+                return node;
+              }));                       
+              this.rootPaths.set(roots);
             } else {
+              this.initialNodes.set([]);
               this.rootPaths.set(['/']);
             }
           },
@@ -221,14 +243,38 @@ export default class SelectFilesComponent {
             const paths = ((res as any)['Files'] as any[]).map((x) => x.Path ?? '');
 
             if (paths.length > 0) {
+              this.initialNodes.set([]);
               this.rootPaths.set(paths);
             } else {
+              this.initialNodes.set([]);
               this.rootPaths.set(['/']);
             }
           },
         });
     }
   }
+
+  splitRootsAndDescendants(paths: string[]): { roots: string[], descendants: string[] } {
+    const normalized = paths.map(p => p.replace(/[/\\]+$/, '\\').toLowerCase());
+  
+    const roots: string[] = [];
+    const descendants: string[] = [];
+  
+    for (let i = 0; i < normalized.length; i++) {
+      const current = normalized[i];
+      const isDescendant = normalized.some((other, j) =>
+        i !== j && current.startsWith(other) && current !== other
+      );
+  
+      if (isDescendant) {
+        descendants.push(paths[i]); // preserve original case
+      } else {
+        roots.push(paths[i]);
+      }
+    }
+  
+    return { roots, descendants };
+  }    
 
   abortLoading$ = new Subject();
   abortLoading() {


### PR DESCRIPTION
This PR introduces two new edit field types: Hostname and Bucketname.

These two fields validate the input as a hostname and bucket name respectively. They also prevent entering `/` into the text field as that trips up the parser because it splits host/path or bucket/path on the first `/`.

The destination config was updated to use appropriate types.

A few helper functions were added to avoid repeated parsing logic in the config file. Most configs can now call the `buildUrlFromFields` directly as the single combination step.

To get this working, the path field now has no leading slash in the path when editing, except when opting for root filesystem.

Streamlined use of `/` and `pathDelimiter`.

Also added support for not showing subfolders as selected in single-select mode.

Added support for cases where the restore flow returns several root folders, like:
```
C:\Folder1\FolderA
C:\Folder1\FolderB
C:\Folder1\FolderB\FolderC
```

Added support for setting the eval state of the root node to reflect the selection state.