### PR TITLE
Allow toggle-cards to overflow with scrollbars, #407

### DIFF
--- a/projects/ngclient/src/app/core/components/toggle-card/toggle-card.component.scss
+++ b/projects/ngclient/src/app/core/components/toggle-card/toggle-card.component.scss
@@ -9,6 +9,7 @@
   &.active {
     .content {
       max-height: 1000px;
+      overflow: auto;
       transition: max-height 1s linear;
       padding: p2r(0 16 16);
     }


### PR DESCRIPTION
The filters were there but hidden when there were too many items for the max-height. This changes the overflow to show scrollbars when needed.