### PR TITLE
fix: rename 'System settings' panel heading to 'Server settings' for consistency with tab name

### DIFF
--- a/projects/ngclient/src/app/about/server-settings/server-settings.component.html
+++ b/projects/ngclient/src/app/about/server-settings/server-settings.component.html
@@ -1,4 +1,4 @@
-<h3 i18n>System settings</h3>
+<h3 i18n>Server settings</h3>
 
 <code>
   <pre>{{ serverSettings() | json }}</pre>


### PR DESCRIPTION
Fixes #397 