### PR TITLE
Clarify custom schedule behavior

### DIFF
--- a/projects/ngclient/src/app/backup/schedule-v2/schedule-summary.ts
+++ b/projects/ngclient/src/app/backup/schedule-v2/schedule-summary.ts
@@ -1,0 +1,39 @@
+type Days = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun';
+type AllowedDays = Record<Days, boolean>;
+
+export function formatRepeatInterval(value: number, unit: string) {
+  switch (unit) {
+    case 's':
+      return value === 1 ? $localize`Every 1 second` : $localize`Every ${value} seconds`;
+    case 'm':
+      return value === 1 ? $localize`Every 1 minute` : $localize`Every ${value} minutes`;
+    case 'h':
+      return value === 1 ? $localize`Every 1 hour` : $localize`Every ${value} hours`;
+    case 'W':
+      return value === 1 ? $localize`Every 1 week` : $localize`Every ${value} weeks`;
+    case 'M':
+      return value === 1 ? $localize`Every 1 month` : $localize`Every ${value} months`;
+    case 'Y':
+      return value === 1 ? $localize`Every 1 year` : $localize`Every ${value} years`;
+    case 'D':
+    default:
+      return value === 1 ? $localize`Every 1 day` : $localize`Every ${value} days`;
+  }
+}
+
+export function formatAllowedDays(allowedDays: AllowedDays) {
+  const days = [
+    allowedDays.mon ? $localize`Monday` : null,
+    allowedDays.tue ? $localize`Tuesday` : null,
+    allowedDays.wed ? $localize`Wednesday` : null,
+    allowedDays.thu ? $localize`Thursday` : null,
+    allowedDays.fri ? $localize`Friday` : null,
+    allowedDays.sat ? $localize`Saturday` : null,
+    allowedDays.sun ? $localize`Sunday` : null,
+  ].filter((day) => day !== null);
+
+  if (days.length === 7) return $localize`Every day`;
+  if (days.length === 0) return $localize`No days selected`;
+
+  return days.join(', ');
+}

--- a/projects/ngclient/src/app/backup/schedule-v2/schedule-summary.ts
+++ b/projects/ngclient/src/app/backup/schedule-v2/schedule-summary.ts
@@ -1,39 +1,27 @@
-type Days = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun';
+import type dayjs from 'dayjs/esm';
+
+const DAY_KEYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const;
+type Days = (typeof DAY_KEYS)[number];
 type AllowedDays = Record<Days, boolean>;
 
-export function formatRepeatInterval(value: number, unit: string) {
-  switch (unit) {
-    case 's':
-      return value === 1 ? $localize`Every 1 second` : $localize`Every ${value} seconds`;
-    case 'm':
-      return value === 1 ? $localize`Every 1 minute` : $localize`Every ${value} minutes`;
-    case 'h':
-      return value === 1 ? $localize`Every 1 hour` : $localize`Every ${value} hours`;
-    case 'W':
-      return value === 1 ? $localize`Every 1 week` : $localize`Every ${value} weeks`;
-    case 'M':
-      return value === 1 ? $localize`Every 1 month` : $localize`Every ${value} months`;
-    case 'Y':
-      return value === 1 ? $localize`Every 1 year` : $localize`Every ${value} years`;
-    case 'D':
-    default:
-      return value === 1 ? $localize`Every 1 day` : $localize`Every ${value} days`;
-  }
-}
+// Day.js day-of-week index for each key (Sunday = 0)
+const DAY_INDEX: Record<Days, number> = {
+  mon: 1,
+  tue: 2,
+  wed: 3,
+  thu: 4,
+  fri: 5,
+  sat: 6,
+  sun: 0,
+};
 
-export function formatAllowedDays(allowedDays: AllowedDays) {
-  const days = [
-    allowedDays.mon ? $localize`Monday` : null,
-    allowedDays.tue ? $localize`Tuesday` : null,
-    allowedDays.wed ? $localize`Wednesday` : null,
-    allowedDays.thu ? $localize`Thursday` : null,
-    allowedDays.fri ? $localize`Friday` : null,
-    allowedDays.sat ? $localize`Saturday` : null,
-    allowedDays.sun ? $localize`Sunday` : null,
-  ].filter((day) => day !== null);
+export function formatAllowedDays(dayjsInstance: typeof dayjs, allowedDays: AllowedDays) {
+  const days = DAY_KEYS.filter((key) => allowedDays[key]).map((key) =>
+    dayjsInstance().day(DAY_INDEX[key]).format('dddd')
+  );
 
-  if (days.length === 7) return $localize`Every day`;
+  if (days.length === 7) return $localize`All days`;
   if (days.length === 0) return $localize`No days selected`;
 
-  return days.join(', ');
+  return new Intl.ListFormat(dayjsInstance.locale(), { style: 'long', type: 'conjunction' }).format(days);
 }

--- a/projects/ngclient/src/app/backup/schedule-v2/schedule.component.html
+++ b/projects/ngclient/src/app/backup/schedule-v2/schedule.component.html
@@ -19,6 +19,32 @@
     <p i18n>If a date was missed, the job will run as soon as possible.</p>
   </div>
 
+  @let summary = scheduleSummary();
+  <section class="schedule-summary" aria-live="polite">
+    <h4 i18n>Schedule summary</h4>
+
+    @if (summary.autoRun) {
+      <dl>
+        <div>
+          <dt i18n>First run</dt>
+          <dd i18n>{{ summary.date }} at {{ summary.time }}</dd>
+        </div>
+        <div>
+          <dt i18n>Repeats</dt>
+          <dd>{{ summary.repeat }}</dd>
+        </div>
+        <div>
+          <dt i18n>Allowed days</dt>
+          <dd>{{ summary.allowedDays }}</dd>
+        </div>
+      </dl>
+
+      <p i18n>The first run sets the anchor for the recurring schedule.</p>
+    } @else {
+      <p i18n>Backups will not run automatically.</p>
+    }
+  </section>
+
   @if (scheduleFields.autoRun()) {
     <div class="row-inputs">
       <sh-form-field>

--- a/projects/ngclient/src/app/backup/schedule-v2/schedule.component.html
+++ b/projects/ngclient/src/app/backup/schedule-v2/schedule.component.html
@@ -31,7 +31,37 @@
         </div>
         <div>
           <dt i18n>Repeats</dt>
-          <dd>{{ summary.repeat }}</dd>
+          <dd>
+            @if (summary.repeatUnit === 's') {
+              <span i18n>
+                {summary.repeatValue, plural, =1 {Every second} other {Every {{summary.repeatValue}} seconds}}
+              </span>
+            } @else if (summary.repeatUnit === 'm') {
+              <span i18n>
+                {summary.repeatValue, plural, =1 {Every minute} other {Every {{summary.repeatValue}} minutes}}
+              </span>
+            } @else if (summary.repeatUnit === 'h') {
+              <span i18n>
+                {summary.repeatValue, plural, =1 {Every hour} other {Every {{summary.repeatValue}} hours}}
+              </span>
+            } @else if (summary.repeatUnit === 'W') {
+              <span i18n>
+                {summary.repeatValue, plural, =1 {Every week} other {Every {{summary.repeatValue}} weeks}}
+              </span>
+            } @else if (summary.repeatUnit === 'M') {
+              <span i18n>
+                {summary.repeatValue, plural, =1 {Every month} other {Every {{summary.repeatValue}} months}}
+              </span>
+            } @else if (summary.repeatUnit === 'Y') {
+              <span i18n>
+                {summary.repeatValue, plural, =1 {Every year} other {Every {{summary.repeatValue}} years}}
+              </span>
+            } @else {
+              <span i18n>
+                {summary.repeatValue, plural, =1 {Every day} other {Every {{summary.repeatValue}} days}}
+              </span>
+            }
+          </dd>
         </div>
         <div>
           <dt i18n>Allowed days</dt>

--- a/projects/ngclient/src/app/backup/schedule-v2/schedule.component.scss
+++ b/projects/ngclient/src/app/backup/schedule-v2/schedule.component.scss
@@ -17,6 +17,38 @@
   gap: p2r(4);
 }
 
+.schedule-summary {
+  display: flex;
+  flex-direction: column;
+  gap: p2r(12);
+  padding: p2r(16);
+  border: p2r(1) solid var(--base-4);
+  border-radius: p2r(8);
+  background: var(--base-1);
+
+  h4,
+  p,
+  dl,
+  dd {
+    margin: 0;
+  }
+
+  dl {
+    display: grid;
+    gap: p2r(8);
+  }
+
+  dl > div {
+    display: grid;
+    grid-template-columns: minmax(p2r(100), 1fr) 2fr;
+    gap: p2r(12);
+  }
+
+  dt {
+    color: var(--base-8);
+  }
+}
+
 .row-inputs {
   display: flex;
   align-items: flex-end;

--- a/projects/ngclient/src/app/backup/schedule-v2/schedule.component.spec.ts
+++ b/projects/ngclient/src/app/backup/schedule-v2/schedule.component.spec.ts
@@ -1,0 +1,37 @@
+/// <reference types="@angular/localize" />
+
+import { describe, expect, it } from 'vitest';
+import { formatAllowedDays, formatRepeatInterval } from './schedule-summary';
+
+describe('schedule summary formatting', () => {
+  it.each([
+    ['s', 'second', 'seconds'],
+    ['m', 'minute', 'minutes'],
+    ['h', 'hour', 'hours'],
+    ['D', 'day', 'days'],
+    ['W', 'week', 'weeks'],
+    ['M', 'month', 'months'],
+    ['Y', 'year', 'years'],
+  ])('formats singular and plural %s intervals', (unit, singular, plural) => {
+    expect(formatRepeatInterval(1, unit)).toBe(`Every 1 ${singular}`);
+    expect(formatRepeatInterval(2, unit)).toBe(`Every 2 ${plural}`);
+  });
+
+  it('formats all allowed days', () => {
+    expect(formatAllowedDays({ mon: true, tue: true, wed: true, thu: true, fri: true, sat: true, sun: true })).toBe(
+      'Every day'
+    );
+  });
+
+  it('formats no allowed days', () => {
+    expect(
+      formatAllowedDays({ mon: false, tue: false, wed: false, thu: false, fri: false, sat: false, sun: false })
+    ).toBe('No days selected');
+  });
+
+  it('formats a subset of allowed days', () => {
+    expect(formatAllowedDays({ mon: true, tue: false, wed: true, thu: false, fri: true, sat: false, sun: false })).toBe(
+      'Monday, Wednesday, Friday'
+    );
+  });
+});

--- a/projects/ngclient/src/app/backup/schedule-v2/schedule.component.spec.ts
+++ b/projects/ngclient/src/app/backup/schedule-v2/schedule.component.spec.ts
@@ -1,37 +1,25 @@
 /// <reference types="@angular/localize" />
 
+import dayjs from 'dayjs/esm';
 import { describe, expect, it } from 'vitest';
-import { formatAllowedDays, formatRepeatInterval } from './schedule-summary';
+import { formatAllowedDays } from './schedule-summary';
 
 describe('schedule summary formatting', () => {
-  it.each([
-    ['s', 'second', 'seconds'],
-    ['m', 'minute', 'minutes'],
-    ['h', 'hour', 'hours'],
-    ['D', 'day', 'days'],
-    ['W', 'week', 'weeks'],
-    ['M', 'month', 'months'],
-    ['Y', 'year', 'years'],
-  ])('formats singular and plural %s intervals', (unit, singular, plural) => {
-    expect(formatRepeatInterval(1, unit)).toBe(`Every 1 ${singular}`);
-    expect(formatRepeatInterval(2, unit)).toBe(`Every 2 ${plural}`);
-  });
-
   it('formats all allowed days', () => {
-    expect(formatAllowedDays({ mon: true, tue: true, wed: true, thu: true, fri: true, sat: true, sun: true })).toBe(
-      'Every day'
-    );
+    expect(
+      formatAllowedDays(dayjs, { mon: true, tue: true, wed: true, thu: true, fri: true, sat: true, sun: true })
+    ).toBe('All days');
   });
 
   it('formats no allowed days', () => {
     expect(
-      formatAllowedDays({ mon: false, tue: false, wed: false, thu: false, fri: false, sat: false, sun: false })
+      formatAllowedDays(dayjs, { mon: false, tue: false, wed: false, thu: false, fri: false, sat: false, sun: false })
     ).toBe('No days selected');
   });
 
   it('formats a subset of allowed days', () => {
-    expect(formatAllowedDays({ mon: true, tue: false, wed: true, thu: false, fri: true, sat: false, sun: false })).toBe(
-      'Monday, Wednesday, Friday'
-    );
+    expect(
+      formatAllowedDays(dayjs, { mon: true, tue: false, wed: true, thu: false, fri: true, sat: false, sun: false })
+    ).toBe('Monday, Wednesday, and Friday');
   });
 });

--- a/projects/ngclient/src/app/backup/schedule-v2/schedule.component.ts
+++ b/projects/ngclient/src/app/backup/schedule-v2/schedule.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ShipButton } from '@ship-ui/core/ship-button';
@@ -10,6 +10,7 @@ import { ShipToggle } from '@ship-ui/core/ship-toggle';
 import { ShipToggleCard } from '@ship-ui/core/ship-toggle-card';
 import { DayOfWeek, ScheduleInputDto } from '../../core/openapi';
 import { BackupState } from '../backup.state';
+import { formatAllowedDays, formatRepeatInterval } from './schedule-summary';
 
 const UNIT_OPTIONS = [
   {
@@ -220,8 +221,6 @@ function getNextMondayAt12PM() {
   return d;
 }
 
-export type Days = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun';
-
 export const SCHEDULE_FIELD_DEFAULTS = () => {
   return {
     autoRun: signal(true),
@@ -271,6 +270,34 @@ export default class ScheduleComponent {
   scheduleFields = this.#backupState.scheduleFields;
   scheduleType = this.#backupState.scheduleType;
   scheduleOptions = SCHEDULE_DEFAULT_OPTIONS;
+  scheduleSummary = computed(() => {
+    if (!this.scheduleFields.autoRun()) {
+      return {
+        autoRun: false as const,
+      };
+    }
+
+    const allowedDays = this.scheduleFields.runAgain.allowedDays;
+
+    return {
+      autoRun: true as const,
+      date: this.scheduleFields.nextTime.date(),
+      time: this.scheduleFields.nextTime.time(),
+      repeat: formatRepeatInterval(
+        this.scheduleFields.runAgain.repeatValue(),
+        this.scheduleFields.runAgain.repeatUnit()
+      ),
+      allowedDays: formatAllowedDays({
+        mon: allowedDays.mon(),
+        tue: allowedDays.tue(),
+        wed: allowedDays.wed(),
+        thu: allowedDays.thu(),
+        fri: allowedDays.fri(),
+        sat: allowedDays.sat(),
+        sun: allowedDays.sun(),
+      }),
+    };
+  });
 
   updateScheduleType(newType: string) {
     const predefinedType = SCHEDULE_DEFAULT_OPTIONS.find((x) => x.value === newType);

--- a/projects/ngclient/src/app/backup/schedule-v2/schedule.component.ts
+++ b/projects/ngclient/src/app/backup/schedule-v2/schedule.component.ts
@@ -9,8 +9,9 @@ import { ShipSelect } from '@ship-ui/core/ship-select';
 import { ShipToggle } from '@ship-ui/core/ship-toggle';
 import { ShipToggleCard } from '@ship-ui/core/ship-toggle-card';
 import { DayOfWeek, ScheduleInputDto } from '../../core/openapi';
+import { DAYJS } from '../../core/providers/dayjs';
 import { BackupState } from '../backup.state';
-import { formatAllowedDays, formatRepeatInterval } from './schedule-summary';
+import { formatAllowedDays } from './schedule-summary';
 
 const UNIT_OPTIONS = [
   {
@@ -265,6 +266,7 @@ export default class ScheduleComponent {
   #backupState = inject(BackupState);
   #router = inject(Router);
   #route = inject(ActivatedRoute);
+  #dayjs = inject(DAYJS);
 
   unitOptions = UNIT_OPTIONS;
   scheduleFields = this.#backupState.scheduleFields;
@@ -283,11 +285,9 @@ export default class ScheduleComponent {
       autoRun: true as const,
       date: this.scheduleFields.nextTime.date(),
       time: this.scheduleFields.nextTime.time(),
-      repeat: formatRepeatInterval(
-        this.scheduleFields.runAgain.repeatValue(),
-        this.scheduleFields.runAgain.repeatUnit()
-      ),
-      allowedDays: formatAllowedDays({
+      repeatValue: this.scheduleFields.runAgain.repeatValue(),
+      repeatUnit: this.scheduleFields.runAgain.repeatUnit(),
+      allowedDays: formatAllowedDays(this.#dayjs, {
         mon: allowedDays.mon(),
         tue: allowedDays.tue(),
         wed: allowedDays.wed(),


### PR DESCRIPTION
## Summary

- add a live schedule summary to the custom schedule editor
- show the first run, repeat interval, and allowed days in plain language
- clarify that the first run establishes the anchor for the recurring schedule
- show an explicit message when automatic backups are disabled

## Root cause

The custom schedule form exposed the individual schedule fields, but did not explain how `Next time`, the repeat interval, and allowed days combine. In particular, it was not clear that the first run time is the anchor used for subsequent repetitions.

## Implementation

The summary is derived entirely from the existing schedule signals and updates as the user edits the form. Repeat intervals handle singular and plural forms for seconds through years, while allowed days distinguish every day, no selected days, and partial selections.

This is display-only: the Schedule API, DTOs, presets, and the saved `Time`, `Repeat`, and `AllowedDays` values are unchanged.

## Screenshots

Both screenshots use the same custom schedule: every 20 minutes, with Tuesday excluded.

| Before | After |
| --- | --- |
| ![Custom schedule before the summary](https://github.com/user-attachments/assets/d62ac1e5-5bdd-4124-9502-559946597c77) | ![Custom schedule with the new summary](https://github.com/user-attachments/assets/c750aeb3-a5ac-42e4-8a85-e40aa58bf693) |

## Validation

- `npx ng build ngclient`
- `npm run test:ci` (2 files, 12 tests)
- `npx prettier --check "projects/ngclient/src/app/backup/schedule-v2/*.{ts,html,scss}"`
- verified in a local Duplicati Server and Angular dev server that changing the interval from 1 day to 20 minutes updates the summary immediately
- verified that deselecting Tuesday updates the allowed-days summary immediately
- verified that the existing custom schedule controls retain their values and behavior

Fixes duplicati/duplicati#6448
