### PR TITLE
Fix commandline output auto-scrolling

### DIFF
--- a/projects/ngclient/src/app/backup/commandline-result/commandline-result.component.html
+++ b/projects/ngclient/src/app/backup/commandline-result/commandline-result.component.html
@@ -31,7 +31,7 @@
     }
   </div>
 
-  <code>
+  <code #logOutput (scroll)="updateAutoScroll()">
     @for (item of messageLog(); track $index) {
       {{ item }}
       <br />

--- a/projects/ngclient/src/app/backup/commandline-result/commandline-result.component.scss
+++ b/projects/ngclient/src/app/backup/commandline-result/commandline-result.component.scss
@@ -2,11 +2,17 @@
 
 :host {
   display: block;
+  height: 100%;
+  min-height: 0;
+  width: 100%;
 }
 
 section {
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
+  height: 100%;
+  min-height: 0;
   width: 100%;
   padding: p2r(40);
   gap: p2r(20);
@@ -17,6 +23,8 @@ code {
   color: #fff;
   padding: p2r(40 40 40 24);
   border-radius: var(--shape-3);
+  flex: 1 1 auto;
+  min-height: 0;
   overflow: auto;
   white-space: pre;
 }

--- a/projects/ngclient/src/app/backup/commandline-result/commandline-result.component.spec.ts
+++ b/projects/ngclient/src/app/backup/commandline-result/commandline-result.component.spec.ts
@@ -1,0 +1,87 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { BehaviorSubject, of } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DuplicatiServer } from '../../core/openapi';
+import CommandlineResultComponent from './commandline-result.component';
+
+describe('CommandlineResultComponent', () => {
+  let component: CommandlineResultComponent;
+  let fixture: ComponentFixture<CommandlineResultComponent>;
+  let logOutput: HTMLElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [CommandlineResultComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            params: new BehaviorSubject({ runId: 'run-id' }),
+            queryParams: new BehaviorSubject({ state: 'state-id' }),
+          },
+        },
+        {
+          provide: DuplicatiServer,
+          useValue: {
+            getApiV1CommandlineByRunid: vi.fn(() => of({})),
+            postApiV1CommandlineByRunidAbort: vi.fn(() => of({})),
+          },
+        },
+      ],
+    });
+
+    TestBed.overrideComponent(CommandlineResultComponent, {
+      set: {
+        imports: [],
+        template: '<code #logOutput (scroll)="updateAutoScroll()">{{ messageLog().join("\\n") }}</code>',
+      },
+    });
+
+    fixture = TestBed.createComponent(CommandlineResultComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    logOutput = fixture.nativeElement.querySelector('code');
+
+    Object.defineProperties(logOutput, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 200 },
+      scrollTop: { configurable: true, value: 100, writable: true },
+    });
+  });
+
+  afterEach(() => {
+    clearInterval(component.interval);
+    fixture.destroy();
+    vi.restoreAllMocks();
+  });
+
+  it('follows new output while the log is at the bottom', () => {
+    component.messageLog.set(['new output']);
+    fixture.detectChanges();
+
+    expect(logOutput.scrollTop).toBe(200);
+  });
+
+  it('pauses while earlier output is being read and resumes at the bottom', () => {
+    logOutput.scrollTop = 40;
+    logOutput.dispatchEvent(new Event('scroll'));
+    fixture.detectChanges();
+
+    expect(component.autoScrollEnabled()).toBe(false);
+
+    component.messageLog.set(['output while paused']);
+    fixture.detectChanges();
+
+    expect(logOutput.scrollTop).toBe(40);
+
+    logOutput.scrollTop = 100;
+    logOutput.dispatchEvent(new Event('scroll'));
+    Object.defineProperty(logOutput, 'scrollHeight', { configurable: true, value: 300 });
+    component.messageLog.update((messages) => [...messages, 'output after resuming']);
+    fixture.detectChanges();
+
+    expect(component.autoScrollEnabled()).toBe(true);
+    expect(logOutput.scrollTop).toBe(300);
+  });
+});

--- a/projects/ngclient/src/app/backup/commandline-result/commandline-result.component.ts
+++ b/projects/ngclient/src/app/backup/commandline-result/commandline-result.component.ts
@@ -1,4 +1,13 @@
-import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import {
+  afterRenderEffect,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  ElementRef,
+  inject,
+  signal,
+  viewChild,
+} from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { ShipButton } from '@ship-ui/core/ship-button';
@@ -26,6 +35,17 @@ export default class CommandlineResultComponent {
   offset = signal<number>(0);
   status = signal<Status>('starting');
   messageLog = signal<string[]>([]);
+  logOutput = viewChild.required<ElementRef<HTMLElement>>('logOutput');
+  autoScrollEnabled = signal(true);
+
+  scrollToBottomEffect = afterRenderEffect(() => {
+    this.messageLog();
+
+    if (!this.autoScrollEnabled()) return;
+
+    const logOutput = this.logOutput().nativeElement;
+    logOutput.scrollTop = logOutput.scrollHeight;
+  });
 
   interval = setInterval(() => {
     this.#dupServer
@@ -50,6 +70,13 @@ export default class CommandlineResultComponent {
     if (res.Started === true && res.Finished === false) {
       this.status.set('started');
     }
+  }
+
+  updateAutoScroll() {
+    const logOutput = this.logOutput().nativeElement;
+    const distanceFromBottom = logOutput.scrollHeight - logOutput.scrollTop - logOutput.clientHeight;
+
+    this.autoScrollEnabled.set(distanceFromBottom <= 2);
   }
 
   abort() {


### PR DESCRIPTION
## Summary

- keep the commandline output pinned to the latest messages as new polling results arrive
- pause automatic scrolling when the user scrolls up to read earlier output
- resume following when the user returns to the bottom
- constrain the output area so it owns the scrolling behavior

## Root cause

Command output was appended to the view without updating the scroll position, and the output element was not constrained as the page's scroll container.

## Visual comparison

The same simulated command output is appended to both panels. The updated behavior follows new output, pauses while earlier output is being read, and resumes after returning to the bottom.

![Before and after comparison](https://github.com/user-attachments/assets/5f6f1511-d236-4a26-93ef-d8d4c4522586)

## Testing

- `npm run test:ci` (4 test files, 10 tests)
- `npx ng build ngclient --configuration development`
- `npx prettier --check` on the changed files
- verified the animated WebP advances in Chromium

Fixes #463