### PR TITLE
Fix source filter highlighting

### DIFF
--- a/projects/ngclient/src/app/core/components/file-tree/file-tree-filter-matcher.spec.ts
+++ b/projects/ngclient/src/app/core/components/file-tree/file-tree-filter-matcher.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { globMatchesPath, regexMatchesPath } from './file-tree-filter-matcher';
+
+describe('file tree filter matching', () => {
+  describe('regular expressions', () => {
+    it('matches against the complete path', () => {
+      expect(regexMatchesPath('C:\\tmp\\folders\\1\\', '.*2')).toBe(false);
+      expect(regexMatchesPath('C:\\tmp\\folders\\12\\', '.*2')).toBe(false);
+      expect(regexMatchesPath('C:\\tmp\\folders\\123\\', '.*2')).toBe(false);
+      expect(regexMatchesPath('C:\\tmp\\folders\\12', '.*2')).toBe(true);
+    });
+
+    it('preserves explicit anchors', () => {
+      expect(regexMatchesPath('folder-12', '^folder-[0-9]+$')).toBe(true);
+      expect(regexMatchesPath('prefix-folder-12', '^folder-[0-9]+$')).toBe(false);
+    });
+  });
+
+  describe('globs', () => {
+    it('matches a Windows folder with single backslashes', () => {
+      const pattern = '*\\1\\';
+
+      expect(globMatchesPath('C:\\tmp\\folders\\1\\', pattern)).toBe(true);
+      expect(globMatchesPath('C:\\tmp\\folders\\12\\', pattern)).toBe(false);
+      expect(globMatchesPath('C:\\tmp\\folders\\123\\', pattern)).toBe(false);
+    });
+
+    it('does not require doubled backslashes', () => {
+      expect(globMatchesPath('C:\\tmp\\folders\\1\\', '*\\\\1\\\\')).toBe(false);
+    });
+
+    it('treats regular expression metacharacters as literals', () => {
+      const path = 'C:\\tmp\\folders\\1\\';
+
+      expect(globMatchesPath(path, 'C:\\t.p\\folders\\1\\')).toBe(false);
+      expect(globMatchesPath(path, 'C:\\tm{1}p\\folders\\1\\')).toBe(false);
+      expect(globMatchesPath(path, 'C:\\tmp\\folders\\1\\')).toBe(true);
+    });
+
+    it('supports star and single-character wildcards across the full path', () => {
+      expect(globMatchesPath('C:\\tmp\\folders\\1\\', '*\\folders\\?\\')).toBe(true);
+      expect(globMatchesPath('C:\\tmp\\folders\\12\\', '*\\folders\\?\\')).toBe(false);
+      expect(globMatchesPath('C:\\tmp\\folders\\1\\', 'tmp\\folders\\1\\')).toBe(false);
+    });
+  });
+});

--- a/projects/ngclient/src/app/core/components/file-tree/file-tree-filter-matcher.ts
+++ b/projects/ngclient/src/app/core/components/file-tree/file-tree-filter-matcher.ts
@@ -1,0 +1,25 @@
+export function translateCSharpRegex(csharpRegex: string): string {
+  let jsRegex = csharpRegex.replace(/^@/, '');
+
+  const namedGroupRegex = /\(\?<(?<name>\w+)>(?<pattern>[^)]+)\)/g;
+  jsRegex = jsRegex.replace(namedGroupRegex, (match, name, pattern) => `(${pattern})`);
+
+  return jsRegex.replace(/\\/g, '\\\\');
+}
+
+export function regexMatchesPath(path: string, csharpRegex: string): boolean {
+  const jsRegex = translateCSharpRegex(csharpRegex);
+  const fullPathRegex = jsRegex.startsWith('^') && jsRegex.endsWith('$') ? jsRegex : `^(${jsRegex})$`;
+
+  return new RegExp(fullPathRegex).test(path);
+}
+
+export function globMatchesPath(path: string, pattern: string): boolean {
+  const regexPattern = pattern.replace(/[\\.+^${}()|[\]*?]/g, (match) => {
+    if (match === '*') return '.*';
+    if (match === '?') return '.';
+    return '\\' + match;
+  });
+
+  return new RegExp(`^${regexPattern}$`).test(path);
+}

--- a/projects/ngclient/src/app/core/components/file-tree/file-tree.component.ts
+++ b/projects/ngclient/src/app/core/components/file-tree/file-tree.component.ts
@@ -36,6 +36,7 @@ import {
 import { BytesPipe } from '../../pipes/byte.pipe';
 import { SysinfoState } from '../../states/sysinfo.state';
 import { ConfirmDialogComponent } from '../confirm-dialog/confirm-dialog.component';
+import { globMatchesPath, regexMatchesPath } from './file-tree-filter-matcher';
 
 enum TreeEvalEnum {
   ExcludedByParent = -2,
@@ -810,9 +811,7 @@ export default class FileTreeComponent {
       if (x.startsWith('[') && x.endsWith(']')) {
         // Works - Regex
         const regexPattern = x.slice(1, -1);
-        const jsRegex = this.translateCSharpRegex(regexPattern);
-        const regex = new RegExp(`${jsRegex}`);
-        const res = regex.test(nodeId!);
+        const res = regexMatchesPath(nodeId!, regexPattern);
 
         if (res) {
           result = dir;
@@ -825,7 +824,7 @@ export default class FileTreeComponent {
         if (nodeType !== 'file') continue;
         if (x.replace('*.', '').length === 0) continue;
 
-        const res = this.#globMatch(nodeId!, x, true);
+        const res = globMatchesPath(nodeId!, x);
 
         if (res) {
           result = dir;
@@ -842,7 +841,7 @@ export default class FileTreeComponent {
         break;
       }
 
-      const res = this.#globMatch(nodeId!, x, true);
+      const res = globMatchesPath(nodeId!, x);
 
       if (res) {
         result = dir;
@@ -851,25 +850,6 @@ export default class FileTreeComponent {
     }
 
     return result;
-  }
-
-  translateCSharpRegex(csharpRegex: string) {
-    let jsRegex = csharpRegex;
-
-    // 1. Remove verbatim string literal indicator (@)
-    jsRegex = jsRegex.replace(/^@/, '');
-
-    // 2. Handle named capture groups
-    //    (This is a simplification - it won't handle nested groups perfectly)
-    const namedGroupRegex = /\(\?<(?<name>\w+)>(?<pattern>[^)]+)\)/g;
-    jsRegex = jsRegex.replace(namedGroupRegex, (match, name, pattern) => `(${pattern})`);
-
-    // TODO - Add lookbehind polyfill
-
-    // 3. Escape backslashes
-    jsRegex = jsRegex.replace(/\\/g, '\\\\');
-
-    return jsRegex;
   }
 
   isIndeterminate(currentPaths: string[], nodeId: string) {
@@ -887,18 +867,6 @@ export default class FileTreeComponent {
         !currentPath.includes('/') &&
         !currentPath.includes('\\'))
     );
-  }
-
-  #globMatch(str: string, pattern: string, evaluateFullPath = false): boolean {
-    const regexPattern = pattern.replace(/[\\.+^${}()|[\]*?]/g, (match) => {
-      if (match === '*') return '.*';
-      if (match === '?') return '.';
-      return '\\' + match;
-    });
-
-    const regex = new RegExp(`${regexPattern}${evaluateFullPath ? '$' : ''}`);
-
-    return regex.test(str);
   }
 
   #getPathDelimiter(path?: string | null): string {


### PR DESCRIPTION
## Summary

- evaluate regular-expression filters against the complete source path, matching Duplicati's implicit anchoring
- use one testable local matcher for regular expressions and globs
- preserve single-backslash Windows glob matching and treat regex metacharacters literally in globs
- add regression coverage for the examples reported in both issues

## Root cause

The local tree evaluator passed regular-expression filters directly to `RegExp.test()`, allowing partial matches. Glob escaping had already been improved after #473 was reported, but it was private, only right-anchored, and had no regression coverage for the reported Windows paths.

## Visual comparison

![Before and after source filter highlighting](https://github.com/user-attachments/assets/9143cdac-d799-4a04-aaec-f60558f3182b)

## Testing

- `npm run test:ci` (4 test files, 14 tests)
- `npx ng build ngclient --configuration development`
- `npx prettier --check` on the changed files

Fixes #472
Fixes #473