### PR TITLE
Add unit test CI workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,28 @@
+name: Unit Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run unit tests
+        run: bun run test:ci

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,5 @@
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "configVersion": 0,
   "workspaces": {
     "": {
@@ -13,7 +13,7 @@
         "@angular/platform-browser": "22.0.4",
         "@angular/platform-browser-dynamic": "22.0.4",
         "@angular/router": "22.0.4",
-        "@ship-ui/core": "^0.23.0",
+        "@ship-ui/core": "^0.23.5",
         "dayjs": "^1.11.19",
         "marked": "^16.4.2",
         "rxjs": "~7.8.0",
@@ -440,7 +440,7 @@
 
     "@schematics/angular": ["@schematics/angular@22.0.4", "", { "dependencies": { "@angular-devkit/core": "22.0.4", "@angular-devkit/schematics": "22.0.4", "jsonc-parser": "3.3.1", "typescript": "6.0.3" } }, "sha512-P3V3tkqIR+n0GJSv0ibf34/zMtKbFp6kaTjBe5cm/RyXuHbmdaPYjk8PNphkGMypDtWCof1RtNnW/hl832Wnew=="],
 
-    "@ship-ui/core": ["@ship-ui/core@0.23.0", "", { "dependencies": { "@phosphor-icons/web": "^2.1.1", "harfbuzzjs": "^1.2.0", "tslib": "^2.3.0", "wawoff2": "^2.0.1" }, "peerDependencies": { "@angular/common": ">=20", "@angular/core": ">=20", "@modelcontextprotocol/sdk": ">=1.25" }, "bin": { "ship-fg": "bin/ship-fg.mjs", "ship-fg-ts": "bin/ship-fg.ts", "ship-mcp": "bin/mcp/index.js" } }, "sha512-pmXFAaRp4pC0SsJQwmQSw0aq+uJbJ6s9qJFSnwrSiiTiMK3BpZPSbjVeFfKqhFciG+0jsOLMLFk6sG1vvOapOA=="],
+    "@ship-ui/core": ["@ship-ui/core@0.23.5", "", { "dependencies": { "@phosphor-icons/web": "^2.1.1", "harfbuzzjs": "^1.2.0", "tslib": "^2.3.0", "wawoff2": "^2.0.1" }, "peerDependencies": { "@angular/common": ">=20", "@angular/core": ">=20", "@modelcontextprotocol/sdk": ">=1.25" }, "bin": { "ship-fg": "bin/ship-fg.mjs", "ship-fg-ts": "bin/ship-fg.ts", "ship-mcp": "bin/mcp/index.js" } }, "sha512-b26dwNQkz9WcP5qVwNTuGzmNUtOXE4YaE3wfgP7+fwUOYdVjgnyiqbYlY3s/rTJc9w/H1TlEOpRs4uAZmv54qA=="],
 
     "@sigstore/bundle": ["@sigstore/bundle@4.0.0", "", { "dependencies": { "@sigstore/protobuf-specs": "^0.5.0" } }, "sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A=="],
 
@@ -690,7 +690,7 @@
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, ""],
 
-    "express-rate-limit": ["express-rate-limit@8.4.1", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, ""],
+    "express-rate-limit": ["express-rate-limit@8.5.1", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, ""],
 
@@ -778,7 +778,7 @@
 
     "injection-js": ["injection-js@2.6.1", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-dbR5bdhi7TWDoCye9cByZqeg/gAfamm8Vu3G1KZOTYkOif8WkuM8CD0oeDPtZYMzT5YH76JAFB7bkmyY9OJi2A=="],
 
-    "ip-address": ["ip-address@10.1.0", "", {}, ""],
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, ""],
 


### PR DESCRIPTION
## Summary

- run the existing Vitest unit tests on pushes to `main` and pull requests
- allow maintainers to run the workflow manually with `workflow_dispatch`
- use Bun for dependency installation and test execution
- regenerate `bun.lock` with the current stable Bun lockfile format

## Why

The repository already has Vitest unit tests, but they are not currently exercised by CI. Running them for every pull request catches regressions before merge.

The existing `bun.lock` used `lockfileVersion: 2`, which stable Bun 1.3.14 could not parse, and it was out of sync with `package.json`. Regenerating it is required for `bun install --frozen-lockfile` to work reliably in CI.

This is part of #273.

## Validation

- `bun install --frozen-lockfile`
- `bun run test:ci` (3 test files, 8 tests passed)
- `bunx prettier --check .github/workflows/unit-tests.yml`
