### PR TITLE
Add formatting utility tests

### DIFF
--- a/projects/ngclient/src/app/core/pipes/byte.pipe.spec.ts
+++ b/projects/ngclient/src/app/core/pipes/byte.pipe.spec.ts
@@ -1,0 +1,48 @@
+import { DecimalPipe } from '@angular/common';
+import { TestBed } from '@angular/core/testing';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BytesPipe } from './byte.pipe';
+
+describe('BytesPipe', () => {
+  let pipe: BytesPipe;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [BytesPipe, DecimalPipe],
+    });
+    pipe = TestBed.inject(BytesPipe);
+    vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue('Mozilla/5.0 (X11; Linux x86_64)');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([null, undefined, '', 'not-a-number'] as const)('returns an empty string for %s', (value) => {
+    expect(pipe.transform(value)).toBe('');
+  });
+
+  it('hides zero by default', () => {
+    expect(pipe.transform(0)).toBe('');
+  });
+
+  it('formats zero when it is explicitly allowed', () => {
+    expect(pipe.transform(0, false, true)).toBe('0B');
+    expect(pipe.transform(0, true, true)).toBe('0 Bytes');
+  });
+
+  it('uses binary units on non-Mac platforms', () => {
+    expect(pipe.transform(1536)).toBe('1.5 KiB');
+    expect(pipe.transform(1536, true)).toBe('1.5 KiB');
+  });
+
+  it('uses decimal units on Mac platforms', () => {
+    vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue('Mozilla/5.0 (Macintosh; Intel Mac OS X)');
+
+    expect(pipe.transform(1500)).toBe('1.5 KB');
+  });
+
+  it('accepts numeric strings', () => {
+    expect(pipe.transform('2048')).toBe('2 KiB');
+  });
+});

--- a/projects/ngclient/src/app/core/pipes/duration.pipe.spec.ts
+++ b/projects/ngclient/src/app/core/pipes/duration.pipe.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DAYJS } from '../providers/dayjs';
+import { DurationFormatPipe } from './duration.pipe';
+
+describe('DurationFormatPipe', () => {
+  const humanize = vi.fn();
+  const duration = vi.fn(() => ({ humanize }));
+  let pipe: DurationFormatPipe;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    TestBed.configureTestingModule({
+      providers: [DurationFormatPipe, { provide: DAYJS, useValue: { duration } }],
+    });
+    pipe = TestBed.inject(DurationFormatPipe);
+  });
+
+  it.each([null, undefined, ''] as const)('returns an empty string for %s', (value) => {
+    expect(pipe.transform(value)).toBe('');
+  });
+
+  it.each(['invalid', '1:2:03', '12:34'])('returns an empty string for an invalid duration: %s', (value) => {
+    expect(pipe.transform(value)).toBe('');
+  });
+
+  it('humanizes a duration through Day.js', () => {
+    humanize.mockReturnValue('3 days');
+
+    expect(pipe.transform('2.03:04:05.123')).toBe('3 days');
+    expect(duration).toHaveBeenCalledWith({ days: 2, hours: 3, minutes: 4, seconds: 5 });
+  });
+
+  it('returns the exact duration when requested', () => {
+    expect(pipe.transform('2.03:04:05', true)).toBe('2d 3h 4m 5s');
+    expect(pipe.transform('03:04:05', true)).toBe('3h 4m 5s');
+    expect(duration).not.toHaveBeenCalled();
+  });
+});

--- a/projects/ngclient/src/app/core/pipes/relative-time.pipe.spec.ts
+++ b/projects/ngclient/src/app/core/pipes/relative-time.pipe.spec.ts
@@ -1,0 +1,52 @@
+import { DatePipe } from '@angular/common';
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DAYJS } from '../providers/dayjs';
+import { RelativeTimePipe } from './relative-time.pipe';
+
+describe('RelativeTimePipe', () => {
+  const fromNow = vi.fn();
+  const dayjs = Object.assign(
+    vi.fn(() => ({ fromNow })),
+    { locale: vi.fn() }
+  );
+  const datePipe = { transform: vi.fn() };
+  let pipe: RelativeTimePipe;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    TestBed.configureTestingModule({
+      providers: [RelativeTimePipe, { provide: DAYJS, useValue: dayjs }, { provide: DatePipe, useValue: datePipe }],
+    });
+    pipe = TestBed.inject(RelativeTimePipe);
+  });
+
+  it.each([null, undefined, ''] as const)('returns N/A for %s', (value) => {
+    expect(pipe.transform(value)).toBe('N/A');
+  });
+
+  it('formats the actual date when requested', () => {
+    const value = new Date('2026-06-14T08:50:00Z');
+    datePipe.transform.mockReturnValue('6/14/26, 8:50 AM');
+
+    expect(pipe.transform(value, true)).toBe('6/14/26, 8:50 AM');
+    expect(datePipe.transform).toHaveBeenCalledWith(value, 'short');
+    expect(dayjs).not.toHaveBeenCalled();
+  });
+
+  it('converts a basic ISO timestamp before calculating relative time', () => {
+    fromNow.mockReturnValue('a few seconds ago');
+
+    expect(pipe.transform('20260614T085000Z')).toBe('a few seconds ago');
+    expect(dayjs.locale).toHaveBeenCalledOnce();
+    expect(dayjs).toHaveBeenCalledWith('2026-06-14T08:50:00Z');
+  });
+
+  it('passes other supported values directly to Day.js', () => {
+    const value = new Date('2026-06-14T08:50:00Z');
+    fromNow.mockReturnValue('a month ago');
+
+    expect(pipe.transform(value)).toBe('a month ago');
+    expect(dayjs).toHaveBeenCalledWith(value);
+  });
+});

--- a/projects/ngclient/src/app/core/services/timespan-literals.service.spec.ts
+++ b/projects/ngclient/src/app/core/services/timespan-literals.service.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { TimespanLiteralsService } from './timespan-literals.service';
+
+describe('TimespanLiteralsService', () => {
+  const service = new TimespanLiteralsService();
+
+  it.each([
+    ['0s', { value: 0, unit: 's' }],
+    ['15m', { value: 15, unit: 'm' }],
+    ['24h', { value: 24, unit: 'h' }],
+    ['7D', { value: 7, unit: 'D' }],
+    ['2W', { value: 2, unit: 'W' }],
+    ['6M', { value: 6, unit: 'M' }],
+    ['1Y', { value: 1, unit: 'Y' }],
+  ] as const)('parses %s', (value, expected) => {
+    expect(service.fromString(value)).toEqual(expected);
+  });
+
+  it.each([null, undefined, '', 'invalid'])('returns null for %s', (value) => {
+    expect(service.fromString(value)).toBeNull();
+  });
+
+  it('serializes a value and unit', () => {
+    expect(service.toString(12, 'h')).toBe('12h');
+  });
+});


### PR DESCRIPTION
## Summary

- add unit tests for byte formatting across empty, zero, numeric string, Mac, and non-Mac inputs
- add unit tests for humanized and exact duration formatting
- add unit tests for actual and relative date formatting, including basic ISO timestamps
- add unit tests for parsing and serializing timespan literals

## Why

These small formatting utilities are used throughout the UI but did not have direct unit test coverage. This PR starts expanding the Vitest suite with a focused, test-only change that is straightforward to review.

Production behavior is unchanged. Potential behavior changes and broader coverage work are intentionally left for separate pull requests.

## Validation

- `bun run test:ci` (7 test files, 43 tests passed)
- `bunx prettier --check` for all four added spec files
