### PR TITLE
Prefill restore options from configured settings

### DIFF
--- a/projects/ngclient/src/app/restore-flow/options/options.component.ts
+++ b/projects/ngclient/src/app/restore-flow/options/options.component.ts
@@ -12,6 +12,7 @@ import FileTreeComponent from '../../core/components/file-tree/file-tree.compone
 import ToggleCardComponent from '../../core/components/toggle-card/toggle-card.component';
 import { SysinfoState } from '../../core/states/sysinfo.state';
 import { RestoreFlowState } from '../restore-flow.state';
+import { RESTORE_OPTION_DEFAULTS } from './restore-option-defaults';
 
 const fb = new FormBuilder();
 
@@ -19,9 +20,9 @@ export const createRestoreOptionsForm = () => {
   return fb.group({
     restoreFrom: fb.control<'original' | 'pickLocation' | 'same-custom' | 'other-custom'>('original'),
     restoreFromPath: fb.control<string>(''),
-    handleExisting: fb.control<'overwrite' | 'saveTimestamp'>('saveTimestamp'),
-    permissions: fb.control<boolean>(false),
-    includeMetadata: fb.control<boolean>(true),
+    handleExisting: fb.control<'overwrite' | 'saveTimestamp'>(RESTORE_OPTION_DEFAULTS.handleExisting),
+    permissions: fb.control<boolean>(RESTORE_OPTION_DEFAULTS.permissions),
+    includeMetadata: fb.control<boolean>(RESTORE_OPTION_DEFAULTS.includeMetadata),
     customRemoteIgnoreExisting: fb.control<boolean>(false),
   });
 };

--- a/projects/ngclient/src/app/restore-flow/options/restore-option-defaults.spec.ts
+++ b/projects/ngclient/src/app/restore-flow/options/restore-option-defaults.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { RESTORE_OPTION_DEFAULTS, resolveRestoreOptionDefaults } from './restore-option-defaults';
+
+describe('resolveRestoreOptionDefaults', () => {
+  it('prefers an enabled backup setting over a disabled server default', () => {
+    const result = resolveRestoreOptionDefaults([{ Name: '--restore-permissions', Value: 'True' }], {
+      '--restore-permissions': 'False',
+    });
+
+    expect(result.permissions).toBe(true);
+  });
+
+  it('prefers a disabled backup setting over an enabled server default', () => {
+    const result = resolveRestoreOptionDefaults([{ Name: 'RESTORE-PERMISSIONS', Value: 'False' }], {
+      '--restore-permissions': 'True',
+    });
+
+    expect(result.permissions).toBe(false);
+  });
+
+  it('uses server defaults when the backup has no matching setting', () => {
+    const result = resolveRestoreOptionDefaults([], {
+      '--restore-permissions': ' yes ',
+      '--skip-metadata': 'ON',
+    });
+
+    expect(result).toEqual({
+      permissions: true,
+      includeMetadata: false,
+    });
+  });
+
+  it('uses the existing form defaults when neither setting is configured', () => {
+    const result = resolveRestoreOptionDefaults(null, {});
+
+    expect(result).toEqual({
+      permissions: RESTORE_OPTION_DEFAULTS.permissions,
+      includeMetadata: RESTORE_OPTION_DEFAULTS.includeMetadata,
+    });
+    expect(RESTORE_OPTION_DEFAULTS.handleExisting).toBe('saveTimestamp');
+  });
+
+  it.each(['true', '1', 'yes', 'on'])('accepts %s as a true boolean value', (value) => {
+    expect(resolveRestoreOptionDefaults([{ Name: 'skip-metadata', Value: value }], {}).includeMetadata).toBe(false);
+  });
+
+  it('treats any other explicit value as false instead of using the lower-priority value', () => {
+    const result = resolveRestoreOptionDefaults([{ Name: '--restore-permissions', Value: 'invalid' }], {
+      '--restore-permissions': 'true',
+    });
+
+    expect(result.permissions).toBe(false);
+  });
+});

--- a/projects/ngclient/src/app/restore-flow/options/restore-option-defaults.ts
+++ b/projects/ngclient/src/app/restore-flow/options/restore-option-defaults.ts
@@ -1,0 +1,50 @@
+import { GetApiV1ServersettingsResponse, SettingDto } from '../../core/openapi';
+
+type RestoreSetting = Pick<SettingDto, 'Name' | 'Value'>;
+
+export const RESTORE_OPTION_DEFAULTS = {
+  handleExisting: 'saveTimestamp' as const,
+  permissions: false,
+  includeMetadata: true,
+};
+
+const TRUE_VALUES = new Set(['true', '1', 'yes', 'on']);
+
+const normalizeOptionName = (name: string | null | undefined) => (name ?? '').trim().replace(/^--/, '').toLowerCase();
+
+const parseBooleanValue = (value: string | null | undefined) => TRUE_VALUES.has((value ?? '').trim().toLowerCase());
+
+const resolveBooleanOption = (
+  optionName: string,
+  backupSettings: RestoreSetting[],
+  serverSettings: GetApiV1ServersettingsResponse,
+  fallback: boolean
+) => {
+  const normalizedName = normalizeOptionName(optionName);
+  const backupSetting = backupSettings.find((setting) => normalizeOptionName(setting.Name) === normalizedName);
+  if (backupSetting) return parseBooleanValue(backupSetting.Value);
+
+  const serverSettingKey = Object.keys(serverSettings).find((key) => normalizeOptionName(key) === normalizedName);
+  if (serverSettingKey) return parseBooleanValue(serverSettings[serverSettingKey]);
+
+  return fallback;
+};
+
+export const resolveRestoreOptionDefaults = (
+  backupSettings: RestoreSetting[] | null | undefined,
+  serverSettings: GetApiV1ServersettingsResponse
+) => {
+  const settings = backupSettings ?? [];
+  const permissions = resolveBooleanOption(
+    'restore-permissions',
+    settings,
+    serverSettings,
+    RESTORE_OPTION_DEFAULTS.permissions
+  );
+  const skipMetadata = resolveBooleanOption('skip-metadata', settings, serverSettings, false);
+
+  return {
+    permissions,
+    includeMetadata: !skipMetadata,
+  };
+};

--- a/projects/ngclient/src/app/restore-flow/restore-flow.state.ts
+++ b/projects/ngclient/src/app/restore-flow/restore-flow.state.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable, signal } from '@angular/core';
+import { effect, inject, Injectable, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ShipDialogService } from '@ship-ui/core/ship-dialog';
@@ -7,7 +7,9 @@ import { TestState } from '../backup/source-data/target-url-dialog/test-url/test
 import { ConfirmDialogComponent } from '../core/components/confirm-dialog/confirm-dialog.component';
 import { DuplicatiServer, GetBackupResultDto, ListFilesetsResponseDto } from '../core/openapi';
 import { SysinfoState } from '../core/states/sysinfo.state';
+import { ServerSettingsService } from '../settings/server-settings.service';
 import { createRestoreOptionsForm } from './options/options.component';
+import { resolveRestoreOptionDefaults } from './options/restore-option-defaults';
 import { createEncryptionForm } from './restore-encryption/restore-encryption.component';
 import { createRestoreSelectFilesForm } from './select-files/select-files.component';
 
@@ -28,6 +30,8 @@ export class RestoreFlowState {
   #sysinfo = inject(SysinfoState);
   #dialog = inject(ShipDialogService);
   #dupServer = inject(DuplicatiServer);
+  #serverSettings = inject(ServerSettingsService);
+  #restoreOptionsInitializedForBackupId: string | null = null;
 
   backupId = signal<string | null>(null);
   backup = signal<GetBackupResultDto | null>(null);
@@ -47,6 +51,19 @@ export class RestoreFlowState {
   extendedDataType = signal<string | null>(null);
   alternateRestorePath = signal<string | null>(null);
   alternateRestorePathSourcePrefix = signal<string | null>(null);
+
+  #initializeRestoreOptions = effect(() => {
+    const backupId = this.backupId();
+    const backup = this.backup()?.Backup;
+    const serverSettings = this.#serverSettings.serverSettings();
+
+    if (!backupId || !backup || serverSettings === undefined) return;
+    if (backup.ID !== null && backup.ID !== backupId) return;
+    if (this.#restoreOptionsInitializedForBackupId === backupId) return;
+
+    this.#restoreOptionsInitializedForBackupId = backupId;
+    this.optionsForm.patchValue(resolveRestoreOptionDefaults(backup.Settings, serverSettings));
+  });
 
   init(id: 'string', isFileRestore = false) {
     this.backupId.set(id);


### PR DESCRIPTION
## Summary

- Prefill the restore permissions and metadata controls from configured backup and server default options.
- Keep the values shown in the UI aligned with the explicit booleans sent by ngclient.
- Preserve the existing overwrite behavior.

## Root cause

The restore form always started with fixed values and always sent those booleans. As a result, the UI silently overrode `--restore-permissions` and `--skip-metadata` from the backup or Settings → Default Options.

## Changes

- Resolve restore options using the precedence: backup settings → server Default Options → existing UI defaults.
- Normalize optional `--` prefixes, option-name casing, and common true values (`true`, `1`, `yes`, and `on`).
- Initialize the form once per backup so navigating back does not overwrite user changes.
- Keep `handleExisting` / `overwrite`, API DTOs, and saved settings unchanged.

## Screenshots

Both screenshots use the same viewport and server Default Options: `--restore-permissions=true` and `--skip-metadata=true`.

| Before | After |
| --- | --- |
| The form uses its fixed defaults: metadata enabled and permissions disabled. | The form reflects the configured defaults: metadata disabled and permissions enabled. |
| <img width="640" alt="Before: fixed restore option defaults" src="https://github.com/user-attachments/assets/88071bd1-1a55-42f2-bf20-758ce8706f37" /> | <img width="640" alt="After: configured restore option defaults" src="https://github.com/user-attachments/assets/6c51d503-334e-4fae-88c7-ff6c0b2c98cd" /> |

## Validation

- `npx prettier --check` for all four changed files
- `npx ng build ngclient`
- `npm run test:ci` — 4 files, 17 tests passed
- Local Angular dev server with a Duplicati Server build containing #7093:
  - a backup-level `restore-permissions=true` overrode a server-level false value and prefilled the permissions control
  - server-level `restore-permissions=true` and `skip-metadata=true` prefilled permissions on and metadata off when the backup had no matching settings
  - user changes survived Go back / Continue navigation
  - an untouched submission sent `permissions: true`, `skip_metadata: false`, and `overwrite: false`, matching the displayed controls
  - a Windows ACL end-to-end restore retained the explicit `BUILTIN\Guests:(R)` ACE after the source file was deleted and restored through the GUI

The repository-wide Prettier check still reports eight pre-existing formatting differences in files not changed by this PR; all changed files pass.

`handleExisting` / `overwrite` intentionally remains unchanged and defaults to save with timestamp.

Depends on duplicati/duplicati#7093

Fixes duplicati/duplicati#4353