### PR TITLE
Add signal utility tests

### DIFF
--- a/projects/ngclient/src/app/core/functions/create-signal.spec.ts
+++ b/projects/ngclient/src/app/core/functions/create-signal.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSignal } from './create-signal';
+
+describe('createSignal', () => {
+  it('exposes the initial value through the getter and value property', () => {
+    const value = createSignal('initial');
+
+    expect(value()).toBe('initial');
+    expect(value.value).toBe('initial');
+  });
+
+  it('supports set and update', () => {
+    const value = createSignal(2);
+
+    value.set(4);
+    value.update((current) => current + 3);
+
+    expect(value()).toBe(7);
+  });
+
+  it('updates the signal by assigning to the value property', () => {
+    const value = createSignal('before');
+
+    value.value = 'after';
+
+    expect(value()).toBe('after');
+  });
+
+  it('passes a custom equality function to the underlying signal', () => {
+    const equal = vi.fn((previous: { id: number }, next: { id: number }) => previous.id === next.id);
+    const value = createSignal({ id: 1, label: 'initial' }, { equal });
+    const initial = value();
+
+    value.set({ id: 1, label: 'ignored' });
+
+    expect(equal).toHaveBeenCalled();
+    expect(value()).toBe(initial);
+
+    value.set({ id: 2, label: 'updated' });
+    expect(value()).toEqual({ id: 2, label: 'updated' });
+  });
+});

--- a/projects/ngclient/src/app/core/functions/lazy-signal.spec.ts
+++ b/projects/ngclient/src/app/core/functions/lazy-signal.spec.ts
@@ -1,0 +1,79 @@
+import { config, of, Subject, throwError } from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+import { LazySignal } from './lazy-signal';
+
+describe('LazySignal', () => {
+  it('starts without a value or loading state', () => {
+    const value = new LazySignal(() => of('loaded'));
+
+    expect(value.value()()).toBeUndefined();
+    expect(value.isLoading()).toBe(false);
+    expect(value.isLoaded()).toBe(false);
+  });
+
+  it('loads a value once and reuses it', () => {
+    const loader = vi.fn(() => of('loaded'));
+    const value = new LazySignal(loader);
+
+    expect(value.load()()).toBe('loaded');
+    expect(value.isLoading()).toBe(false);
+    expect(value.isLoaded()).toBe(true);
+
+    expect(value.load()()).toBe('loaded');
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start another load while one is in progress', () => {
+    const response = new Subject<string>();
+    const loader = vi.fn(() => response.asObservable());
+    const value = new LazySignal(loader);
+
+    const first = value.load();
+    const second = value.load();
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(value.isLoading()).toBe(true);
+    expect(first()).toBeUndefined();
+    expect(second()).toBeUndefined();
+
+    response.next('loaded');
+    response.complete();
+
+    expect(first()).toBe('loaded');
+    expect(value.isLoading()).toBe(false);
+    expect(value.isLoaded()).toBe(true);
+  });
+
+  it('resets the value and allows it to be loaded again', () => {
+    const loader = vi.fn().mockReturnValueOnce(of('first')).mockReturnValueOnce(of('second'));
+    const value = new LazySignal<string>(loader);
+
+    expect(value.load()()).toBe('first');
+
+    value.reset();
+
+    expect(value.value()()).toBeUndefined();
+    expect(value.isLoaded()).toBe(false);
+    expect(value.load()()).toBe('second');
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the loading state when the loader errors', async () => {
+    const error = new Error('load failed');
+    const onUnhandledError = vi.fn();
+    const previousHandler = config.onUnhandledError;
+    config.onUnhandledError = onUnhandledError;
+
+    try {
+      const value = new LazySignal(() => throwError(() => error));
+
+      expect(value.load()()).toBeUndefined();
+      expect(value.isLoading()).toBe(false);
+      expect(value.isLoaded()).toBe(false);
+
+      await vi.waitFor(() => expect(onUnhandledError).toHaveBeenCalledWith(error));
+    } finally {
+      config.onUnhandledError = previousHandler;
+    }
+  });
+});

--- a/projects/ngclient/src/app/core/functions/localstorage-signal.spec.ts
+++ b/projects/ngclient/src/app/core/functions/localstorage-signal.spec.ts
@@ -1,0 +1,83 @@
+import { TestBed } from '@angular/core/testing';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LOCALSTORAGE } from '../services/localstorage.token';
+import { localStorageSignal } from './localstorage-signal';
+
+describe('localStorageSignal', () => {
+  let storage: LOCALSTORAGE;
+
+  beforeEach(() => {
+    storage = {
+      getItemParsed: vi.fn(),
+      setItemParsed: vi.fn(),
+      removeItem: vi.fn(),
+    } as unknown as LOCALSTORAGE;
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: LOCALSTORAGE, useValue: storage }],
+    });
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  function create<T>(initialValue: T, persistThroughClear = false) {
+    return TestBed.runInInjectionContext(() => localStorageSignal('setting', initialValue, persistThroughClear));
+  }
+
+  it('uses the initial value when storage is empty', () => {
+    vi.mocked(storage.getItemParsed).mockReturnValue(null);
+
+    const value = create('initial');
+
+    expect(value()).toBe('initial');
+    expect(storage.getItemParsed).toHaveBeenCalledWith('setting', false);
+  });
+
+  it.each([
+    [false, true],
+    [0, 10],
+  ] as const)('uses the stored value %s instead of the initial value', (stored, initial) => {
+    vi.mocked(storage.getItemParsed).mockReturnValue(stored);
+
+    expect(create(initial)()).toBe(stored);
+  });
+
+  it('persists values set directly', () => {
+    const value = create(1);
+
+    value.set(2);
+
+    expect(value()).toBe(2);
+    expect(storage.setItemParsed).toHaveBeenCalledWith('setting', 2, false);
+  });
+
+  it('persists values produced by update', () => {
+    const value = create(2);
+
+    value.update((current) => current * 3);
+
+    expect(value()).toBe(6);
+    expect(storage.setItemParsed).toHaveBeenCalledWith('setting', 6, false);
+  });
+
+  it.each([null, undefined])('removes the stored value when set to %s', (nextValue) => {
+    const value = create<string | null | undefined>('initial');
+
+    value.set(nextValue);
+
+    expect(value()).toBe(nextValue);
+    expect(storage.removeItem).toHaveBeenCalledWith('setting');
+    expect(storage.setItemParsed).not.toHaveBeenCalled();
+  });
+
+  it('propagates persistThroughClear to reads and writes', () => {
+    const value = create('initial', true);
+
+    value.set('updated');
+
+    expect(storage.getItemParsed).toHaveBeenCalledWith('setting', true);
+    expect(storage.setItemParsed).toHaveBeenCalledWith('setting', 'updated', true);
+  });
+});

--- a/projects/ngclient/src/app/core/signals/parse-recursive-signals-object.spec.ts
+++ b/projects/ngclient/src/app/core/signals/parse-recursive-signals-object.spec.ts
@@ -1,0 +1,39 @@
+import { signal } from '@angular/core';
+import { describe, expect, it } from 'vitest';
+import { parseRecursiveObjectOfSignals } from './parse-recursive-signals-object';
+
+describe('parseRecursiveObjectOfSignals', () => {
+  it.each([null, undefined, true, 42, 'value'])('returns the primitive value %s unchanged', (value) => {
+    expect(parseRecursiveObjectOfSignals(value)).toBe(value);
+  });
+
+  it('unwraps a signal', () => {
+    expect(parseRecursiveObjectOfSignals(signal('value'))).toBe('value');
+  });
+
+  it('recursively unwraps signals in objects', () => {
+    const value = {
+      name: signal('backup'),
+      enabled: signal(true),
+      nested: {
+        count: signal(3),
+        plain: 'value',
+      },
+    };
+
+    expect(parseRecursiveObjectOfSignals(value)).toEqual({
+      name: 'backup',
+      enabled: true,
+      nested: {
+        count: 3,
+        plain: 'value',
+      },
+    });
+  });
+
+  it('recursively unwraps signals in arrays', () => {
+    const value = [signal('first'), { nested: signal('second') }, [signal('third')]];
+
+    expect(parseRecursiveObjectOfSignals(value)).toEqual(['first', { nested: 'second' }, ['third']]);
+  });
+});

--- a/projects/ngclient/src/app/core/signals/revertable-signal.spec.ts
+++ b/projects/ngclient/src/app/core/signals/revertable-signal.spec.ts
@@ -1,0 +1,52 @@
+import { signal } from '@angular/core';
+import { describe, expect, it, vi } from 'vitest';
+import { revertableSignal } from './revertable-signal';
+
+describe('revertableSignal', () => {
+  it('uses the computation value and follows its source', () => {
+    const source = signal(1);
+    const value = revertableSignal(() => source());
+
+    expect(value()).toBe(1);
+
+    source.set(2);
+    expect(value()).toBe(2);
+  });
+
+  it('sets a value and returns a callback that restores the previous value', () => {
+    const value = revertableSignal(() => 'initial');
+
+    const revert = value.set('updated');
+
+    expect(value()).toBe('updated');
+
+    revert();
+    expect(value()).toBe('initial');
+  });
+
+  it('updates a value and returns a callback that restores the previous value', () => {
+    const value = revertableSignal(() => 2);
+
+    const revert = value.update((current) => current * 3);
+
+    expect(value()).toBe(6);
+
+    revert();
+    expect(value()).toBe(2);
+  });
+
+  it('uses a custom equality function', () => {
+    const equal = vi.fn((previous: { id: number }, next: { id: number }) => previous.id === next.id);
+    const value = revertableSignal(() => ({ id: 1, label: 'initial' }), { equal });
+    const initial = value();
+    equal.mockClear();
+
+    value.set({ id: 1, label: 'ignored' });
+
+    expect(equal).toHaveBeenCalled();
+    expect(value()).toBe(initial);
+
+    value.set({ id: 2, label: 'updated' });
+    expect(value()).toEqual({ id: 2, label: 'updated' });
+  });
+});


### PR DESCRIPTION
## Summary
- add focused unit coverage for the shared signal utilities
- verify lazy loading, persistence, recursive signal unwrapping, and reversible updates
- keep asynchronous and storage behavior deterministic with RxJS controls and a typed local storage fake

This is a test-only change. It does not modify production behavior, Angular APIs, dependencies, or persisted data, and it is independent of #494 and #495.

## Test coverage

The new suite adds 29 tests for:

- `createSignal` getters, setters, updates, the `value` property, and custom equality
- `LazySignal` initial state, single-flight loading, successful completion, reset/reload, and error finalization
- `localStorageSignal` stored defaults, false and zero values, set/update persistence, removal, and `persistThroughClear`
- recursive unwrapping of signals in nested objects and arrays
- `revertableSignal` source tracking, reversible set/update operations, and custom equality

Pending-loader resets, non-plain object prototype handling, and ordering multiple revert callbacks remain out of scope because their intended contracts are not defined.

## Validation
- `npm ci --prefer-offline --no-audit --no-fund`
- `bun install --frozen-lockfile`
- Prettier check for all five new spec files
- targeted signal utility tests — 5 files, 29 tests passed
- `ng test ngclient --watch=false` — 15 files, 89 tests passed
- `ng build ngclient --configuration production`

Part of #273