### PR TITLE
Preserve destination editor identity

### DIFF
--- a/projects/ngclient/src/app/backup/backup.state.spec.ts
+++ b/projects/ngclient/src/app/backup/backup.state.spec.ts
@@ -1,0 +1,71 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { ShipDialogService } from '@ship-ui/core/ship-dialog';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { BackupDto, DuplicatiServer } from '../core/openapi';
+import { TimespanLiteralsService } from '../core/services/timespan-literals.service';
+import { ConnectionStringsState } from '../core/states/connection-strings.state';
+import { SysinfoState } from '../core/states/sysinfo.state';
+import { ServerSettingsService } from '../settings/server-settings.service';
+import { BackupState } from './backup.state';
+
+describe('BackupState destination identity', () => {
+  let state: BackupState;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        BackupState,
+        { provide: Router, useValue: { navigate: () => Promise.resolve(true) } },
+        { provide: SysinfoState, useValue: { systemInfo: signal(null) } },
+        { provide: ShipDialogService, useValue: {} },
+        { provide: DuplicatiServer, useValue: {} },
+        { provide: ServerSettingsService, useValue: {} },
+        { provide: TimespanLiteralsService, useValue: {} },
+        { provide: ConnectionStringsState, useValue: { destinations: signal([]) } },
+      ],
+    });
+
+    state = TestBed.inject(BackupState);
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('assigns a distinct UI key to each loaded destination', () => {
+    state.mapDestinationToForm({
+      TargetURL: 'file://C:/backup',
+      ConnectionStringID: -1,
+      AdditionalTargetURLs: [
+        {
+          TargetUrl: 'webdav://example.com/backup',
+          ConnectionStringID: -1,
+          UrlKey: 'secondary',
+          Mode: null,
+          Options: null,
+        },
+      ],
+    } as BackupDto);
+
+    const [local, webdav] = state.targetUrls();
+
+    expect(local.uiKey).toBeTruthy();
+    expect(webdav.uiKey).toBeTruthy();
+    expect(local.uiKey).not.toBe(webdav.uiKey);
+  });
+
+  it('preserves the UI key when a destination is updated', () => {
+    state.addTargetUrl('webdav://example.com/backup', null, 'secondary');
+    const originalKey = state.targetUrls()[0].uiKey;
+
+    state.updateTargetUrl(0, 'webdav://example.com/updated', 42, 'secondary');
+    state.toggleSaveConnectionString(0);
+
+    expect(state.targetUrls()[0]).toMatchObject({
+      uiKey: originalKey,
+      url: 'webdav://example.com/updated',
+      connectionStringId: 42,
+      urlKey: 'secondary',
+    });
+  });
+});

--- a/projects/ngclient/src/app/backup/backup.state.ts
+++ b/projects/ngclient/src/app/backup/backup.state.ts
@@ -5,6 +5,7 @@ import { ShipDialogService } from '@ship-ui/core/ship-dialog';
 import { finalize, forkJoin, map, Observable, of, switchMap, tap } from 'rxjs';
 import { ConfirmDialogComponent } from '../core/components/confirm-dialog/confirm-dialog.component';
 import { splitSize } from '../core/components/size/size.component';
+import { randomUUID } from '../core/functions/crypto';
 import {
   ArgumentType,
   BackupAndScheduleInputDto,
@@ -37,6 +38,27 @@ const SMART_RETENTION = '1W:1D,4W:1W,12M:1M';
 
 const DEFAULT_SAVE_CONNECTIONSTRING = false;
 
+export type BackupTargetUrl = {
+  uiKey: string;
+  url: string;
+  connectionStringId: number | null;
+  urlKey: string | null;
+  save: boolean;
+};
+
+const createBackupTargetUrl = (
+  url: string,
+  connectionStringId: number | null,
+  urlKey: string | null,
+  save: boolean
+): BackupTargetUrl => ({
+  uiKey: randomUUID(),
+  url,
+  connectionStringId,
+  urlKey,
+  save,
+});
+
 @Injectable({
   providedIn: 'root',
 })
@@ -61,7 +83,7 @@ export class BackupState {
     backupRetentionCustom: signal(''),
   };
 
-  targetUrls = signal<{ url: string; connectionStringId: number | null; urlKey: string | null; save: boolean }[]>([]);
+  targetUrls = signal<BackupTargetUrl[]>([]);
   targetUrlModel = computed(() => this.targetUrls()[0]?.url ?? null);
   connectionStringId = computed(() => this.targetUrls()[0]?.connectionStringId ?? null);
 
@@ -318,15 +340,12 @@ export class BackupState {
     const url = backup.TargetURL ?? '';
     const csId = (backup.ConnectionStringID === -1 ? null : backup.ConnectionStringID) ?? null;
 
-    const firstDestination = url ? [{ url, connectionStringId: csId, urlKey: null, save: !!csId }] : [];
+    const firstDestination = url ? [createBackupTargetUrl(url, csId, null, !!csId)] : [];
 
     const additionalDestinations =
-      (anyBackup.AdditionalTargetURLs as TargetUrlDto[])?.map((t) => ({
-        url: t.TargetUrl!,
-        urlKey: t.UrlKey,
-        connectionStringId: t.ConnectionStringID ?? null,
-        save: !!t.ConnectionStringID,
-      })) ?? [];
+      (anyBackup.AdditionalTargetURLs as TargetUrlDto[])?.map((t) =>
+        createBackupTargetUrl(t.TargetUrl!, t.ConnectionStringID ?? null, t.UrlKey ?? null, !!t.ConnectionStringID)
+      ) ?? [];
 
     this.targetUrls.set([...firstDestination, ...additionalDestinations]);
   }
@@ -730,14 +749,17 @@ export class BackupState {
     this.targetUrls.update((urls) => {
       const newUrls = [...urls];
       if (newUrls.length === 0) {
-        newUrls.push({
-          url: targetUrl,
-          urlKey: targetUrlKey,
-          connectionStringId,
-          save: connectionStringId ? true : DEFAULT_SAVE_CONNECTIONSTRING,
-        });
+        newUrls.push(
+          createBackupTargetUrl(
+            targetUrl,
+            connectionStringId,
+            targetUrlKey,
+            connectionStringId ? true : DEFAULT_SAVE_CONNECTIONSTRING
+          )
+        );
       } else {
         newUrls[0] = {
+          ...newUrls[0],
           url: targetUrl,
           urlKey: targetUrlKey,
           connectionStringId,
@@ -752,7 +774,7 @@ export class BackupState {
   addTargetUrl(url: string, connectionStringId: number | null, urlKey: string | null) {
     this.targetUrls.update((urls) => [
       ...urls,
-      { url, connectionStringId, urlKey, save: connectionStringId ? true : DEFAULT_SAVE_CONNECTIONSTRING },
+      createBackupTargetUrl(url, connectionStringId, urlKey, connectionStringId ? true : DEFAULT_SAVE_CONNECTIONSTRING),
     ]);
   }
 
@@ -764,7 +786,13 @@ export class BackupState {
       // If connectionStringId is provided (meaning we probably saved it or loaded it), save should be true?
       // If it's null, we respect existing save flag?
       // Attempting to preserve user intent.
-      newUrls[index] = { url, connectionStringId, urlKey, save: connectionStringId ? true : existingSave };
+      newUrls[index] = {
+        ...newUrls[index],
+        url,
+        connectionStringId,
+        urlKey,
+        save: connectionStringId ? true : existingSave,
+      };
       return newUrls;
     });
   }

--- a/projects/ngclient/src/app/backup/destination/destination.component.html
+++ b/projects/ngclient/src/app/backup/destination/destination.component.html
@@ -9,7 +9,7 @@
 
   <header>
     @if (currentEditingIndex() !== null || (!showCustomList() && !isAddingNew())) {
-      @for (dest of currentTargets; track $index) {
+      @for (dest of currentTargets; track dest.uiKey) {
         @if (showCustomList() && currentEditingIndex() === $index) {
           <sh-card class="destination-card type-c editing">
             <div class="editing-header">

--- a/projects/ngclient/src/app/backup/destination/destination.component.spec.ts
+++ b/projects/ngclient/src/app/backup/destination/destination.component.spec.ts
@@ -1,0 +1,123 @@
+import { CUSTOM_ELEMENTS_SCHEMA, Component, input, output, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { ActivatedRoute, Router } from '@angular/router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectionStringsState } from '../../core/states/connection-strings.state';
+import { BackupState, BackupTargetUrl } from '../backup.state';
+import { TestState } from '../source-data/target-url-dialog/test-url/test-url';
+import DestinationComponent from './destination.component';
+
+@Component({
+  selector: 'app-single-destination',
+  template: '',
+})
+class SingleDestinationStub {
+  targetUrl = input.required<string | null>();
+  targetUrlChange = output<string | null>();
+  useBackupState = input(false);
+}
+
+describe('DestinationComponent destination identity', () => {
+  let fixture: ComponentFixture<DestinationComponent>;
+  let component: DestinationComponent;
+  let targetUrls: ReturnType<typeof signal<BackupTargetUrl[]>>;
+
+  const localTarget: BackupTargetUrl = {
+    uiKey: 'local-target',
+    url: 'file://C:/backup',
+    connectionStringId: null,
+    urlKey: null,
+    save: false,
+  };
+  const webdavTarget: BackupTargetUrl = {
+    uiKey: 'webdav-target',
+    url: 'webdav://example.com/backup',
+    connectionStringId: null,
+    urlKey: 'secondary',
+    save: false,
+  };
+
+  beforeEach(() => {
+    targetUrls = signal([localTarget, webdavTarget]);
+
+    const backupState = {
+      targetUrls,
+      isConnectionStringSaved: signal(false),
+      isNew: signal(false),
+      backupId: signal('backup-id'),
+      removeTargetUrl: vi.fn((index: number) => {
+        targetUrls.update((targets) => targets.filter((_, targetIndex) => targetIndex !== index));
+      }),
+      updateTargetUrl: vi.fn((index: number, url: string, connectionStringId: number | null, urlKey: string | null) => {
+        targetUrls.update((targets) =>
+          targets.map((target, targetIndex) =>
+            targetIndex === index ? { ...target, url, connectionStringId, urlKey } : target
+          )
+        );
+      }),
+    };
+
+    TestBed.configureTestingModule({
+      imports: [DestinationComponent],
+      providers: [
+        { provide: Router, useValue: { navigate: vi.fn() } },
+        { provide: ActivatedRoute, useValue: { parent: {} } },
+        { provide: BackupState, useValue: backupState },
+        {
+          provide: ConnectionStringsState,
+          useValue: {
+            destinations: signal([]),
+            resourceDestinations: { isLoading: signal(false) },
+          },
+        },
+      ],
+    });
+
+    TestBed.overrideComponent(DestinationComponent, {
+      set: {
+        imports: [SingleDestinationStub],
+        schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      },
+    });
+
+    fixture = TestBed.createComponent(DestinationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+    TestBed.resetTestingModule();
+  });
+
+  it('keeps the WebDAV editor instance when the preceding local destination is removed', () => {
+    const editorsBefore = fixture.debugElement.queryAll(By.directive(SingleDestinationStub));
+    const webdavEditor = editorsBefore[1].componentInstance as SingleDestinationStub;
+    const localTestState = { action: 'success' } as TestState;
+    component.testStates.set([localTestState, null]);
+
+    component.removeDestination(0);
+    fixture.detectChanges();
+
+    const editorsAfter = fixture.debugElement.queryAll(By.directive(SingleDestinationStub));
+    expect(editorsAfter).toHaveLength(1);
+    expect(editorsAfter[0].componentInstance).toBe(webdavEditor);
+    expect(webdavEditor.targetUrl()).toBe('webdav://example.com/backup');
+    expect(component.testStates()).toEqual([null]);
+  });
+
+  it('keeps the editor instance when its URL changes', () => {
+    const webdavEditor = fixture.debugElement.queryAll(By.directive(SingleDestinationStub))[1]
+      .componentInstance as SingleDestinationStub;
+
+    component.updateTargetUrl(1, 'webdav://example.com/updated');
+    fixture.detectChanges();
+
+    const updatedEditor = fixture.debugElement.queryAll(By.directive(SingleDestinationStub))[1]
+      .componentInstance as SingleDestinationStub;
+    expect(updatedEditor).toBe(webdavEditor);
+    expect(updatedEditor.targetUrl()).toBe('webdav://example.com/updated');
+    expect(targetUrls()[1].uiKey).toBe('webdav-target');
+  });
+});

--- a/projects/ngclient/src/app/backup/destination/destination.component.ts
+++ b/projects/ngclient/src/app/backup/destination/destination.component.ts
@@ -279,6 +279,7 @@ export default class DestinationComponent {
   }
 
   removeDestination(index: number) {
+    this.testStates.update((states) => states.filter((_, stateIndex) => stateIndex !== index));
     this.#backupState.removeTargetUrl(index);
   }
 


### PR DESCRIPTION
## Summary

- assign each configured destination a UI-only stable key
- track destination editor rows by that key instead of their list index
- remove the matching connection test state when a destination is removed

## Root cause

The destination editor loop tracked rows by `$index`. Removing the first destination therefore reused its `SingleDestinationComponent` instance for the destination that shifted into that position. This could leave a WebDAV destination rendered with state from the removed local destination.

The stable key is created only for client-side row identity. It is preserved when a destination URL is edited and is not included in backup DTOs or persisted configuration.

## Validation

- `bun install --frozen-lockfile`
- `bun x prettier --check` for all changed files
- `bun run test:ci` — 12 files, 64 tests passed
- `bun run gen:font`
- `bun x ng build ngclient --configuration production`

The regression tests verify that removing a preceding local destination preserves the original WebDAV editor instance and its test state, while editing a destination URL does not recreate the row.

Fixes duplicati/duplicati#7087
Fixes duplicati/duplicati#7122