### PR TITLE
Allow encryption changes for imported backups

### DIFF
--- a/projects/ngclient/src/app/backup/backup-encryption-settings.spec.ts
+++ b/projects/ngclient/src/app/backup/backup-encryption-settings.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { SettingDto } from '../core/openapi';
+import { resolveBackupEncryptionSettings } from './backup-encryption-settings';
+
+const settings = (values: Array<[string, string]>) => values.map(([Name, Value]) => ({ Name, Value }) as SettingDto);
+
+describe('resolveBackupEncryptionSettings', () => {
+  it('resolves encryption settings without option prefixes', () => {
+    expect(
+      resolveBackupEncryptionSettings(
+        settings([
+          ['encryption-module', 'aes'],
+          ['passphrase', 'secret'],
+        ])
+      )
+    ).toEqual({
+      encryptionDisabled: false,
+      encryptionModule: 'aes',
+      passphrase: 'secret',
+    });
+  });
+
+  it('normalizes option prefixes and casing', () => {
+    expect(
+      resolveBackupEncryptionSettings(
+        settings([
+          ['--Encryption-Module', 'aes'],
+          ['--PASSPHRASE', 'secret'],
+        ])
+      )
+    ).toEqual({
+      encryptionDisabled: false,
+      encryptionModule: 'aes',
+      passphrase: 'secret',
+    });
+  });
+
+  it.each(['true', 'TRUE', '1', 'yes', 'on'])('recognizes %s as disabling encryption', (value) => {
+    expect(resolveBackupEncryptionSettings(settings([['--no-encryption', value]])).encryptionDisabled).toBe(true);
+  });
+
+  it('does not disable encryption for an explicit false value', () => {
+    expect(
+      resolveBackupEncryptionSettings(
+        settings([
+          ['--no-encryption', 'false'],
+          ['encryption-module', 'aes'],
+        ])
+      )
+    ).toMatchObject({
+      encryptionDisabled: false,
+      encryptionModule: 'aes',
+    });
+  });
+});

--- a/projects/ngclient/src/app/backup/backup-encryption-settings.ts
+++ b/projects/ngclient/src/app/backup/backup-encryption-settings.ts
@@ -1,0 +1,19 @@
+import { SettingDto } from '../core/openapi';
+
+const TRUE_VALUES = new Set(['true', '1', 'yes', 'on']);
+
+const normalizeSettingName = (name: string | null | undefined) => (name ?? '').replace(/^--/, '').toLowerCase();
+
+export const resolveBackupEncryptionSettings = (settings: SettingDto[] | null | undefined) => {
+  const normalizedSettings = (settings ?? []).map((setting) => ({
+    name: normalizeSettingName(setting.Name),
+    value: setting.Value ?? '',
+  }));
+  const getValue = (name: string) => normalizedSettings.find((setting) => setting.name === name)?.value ?? '';
+
+  return {
+    encryptionDisabled: TRUE_VALUES.has(getValue('no-encryption').trim().toLowerCase()),
+    encryptionModule: getValue('encryption-module'),
+    passphrase: getValue('passphrase'),
+  };
+};

--- a/projects/ngclient/src/app/backup/backup.state.ts
+++ b/projects/ngclient/src/app/backup/backup.state.ts
@@ -22,6 +22,7 @@ import { parseRecursiveObjectOfSignals } from '../core/signals/parse-recursive-s
 import { ConnectionStringsState } from '../core/states/connection-strings.state';
 import { SysinfoState } from '../core/states/sysinfo.state';
 import { ServerSettingsService } from '../settings/server-settings.service';
+import { resolveBackupEncryptionSettings } from './backup-encryption-settings';
 import { FormView, getConfigurationByUrl } from './destination/destination.config-utilities';
 import { createGeneralForm, NONE_OPTION } from './general/general.component';
 import { RetentionType } from './options/options.component';
@@ -334,9 +335,7 @@ export class BackupState {
   mapGeneralToForm(backup: BackupDto) {
     const name = backup.Name ?? '';
     const description = backup.Description ?? '';
-    const encryptionModule = backup.Settings?.find((x) => x.Name === 'encryption-module');
-    const passphrase = backup.Settings?.find((x) => x.Name === 'passphrase')?.Value ?? '';
-    const encryption = encryptionModule?.Value && encryptionModule.Value.length ? encryptionModule.Value : '';
+    const { encryptionDisabled, encryptionModule, passphrase } = resolveBackupEncryptionSettings(backup.Settings);
     const operationType = backup.OperationType ?? 'Backup';
 
     const baseUpdate: Partial<typeof this.generalForm.value> = {
@@ -353,14 +352,14 @@ export class BackupState {
       baseUpdate.description = description;
     }
 
-    if (encryption && encryption !== '') {
-      baseUpdate.encryption = encryption;
+    if (encryptionDisabled) {
+      baseUpdate.encryption = NONE_OPTION.Key;
+    } else if (encryptionModule) {
+      baseUpdate.encryption = encryptionModule;
     }
 
-    if (passphrase && passphrase !== '') {
-      baseUpdate.password = passphrase;
-      baseUpdate.repeatPassword = passphrase;
-    }
+    baseUpdate.password = passphrase;
+    baseUpdate.repeatPassword = passphrase;
 
     this.generalForm.patchValue(baseUpdate);
   }

--- a/projects/ngclient/src/app/backup/general/general.component.html
+++ b/projects/ngclient/src/app/backup/general/general.component.html
@@ -7,7 +7,7 @@
         <sh-icon icon>arrows-left-right</sh-icon>
         Synchronization job - files are not encrypted
       </sh-alert>
-    } @else if (generalFormSignal()?.encryption !== '') {
+    } @else if (!canEditEncryption() && generalFormSignal()?.encryption !== '') {
       <sh-alert class="primary" i18n>
         <sh-icon icon>lock</sh-icon>
         Encrypted backup
@@ -61,7 +61,7 @@
       </sh-alert>
     }
   } @else {
-    @if (isNew()) {
+    @if (canEditEncryption()) {
       <sh-select [options]="encryptionOptions()" [isClearable]="false" value="Key" label="DisplayName">
         <label for="encryption" i18n>Encryption</label>
         <input
@@ -165,7 +165,9 @@
       Exit
     </button>
 
-    @if (generalFormSignal()?.operationType === 'Sync' || encryptionFieldSignal() === noneOptionKey || !isNew()) {
+    @if (
+      generalFormSignal()?.operationType === 'Sync' || encryptionFieldSignal() === noneOptionKey || !canEditEncryption()
+    ) {
       <button shButton class="raised primary" type="submit" [disabled]="nameAndDescriptionValid() === false" i18n>
         Continue
         <sh-icon>arrow-right</sh-icon>

--- a/projects/ngclient/src/app/backup/general/general.component.spec.ts
+++ b/projects/ngclient/src/app/backup/general/general.component.spec.ts
@@ -1,0 +1,112 @@
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OperationType } from '../../core/openapi';
+import { PasswordGeneratorService } from '../../core/services/password-generator.service';
+import { SysinfoState } from '../../core/states/sysinfo.state';
+import { BackupState } from '../backup.state';
+import GeneralComponent, { createGeneralForm, NONE_OPTION } from './general.component';
+
+describe('GeneralComponent encryption fields', () => {
+  let fixture: ComponentFixture<GeneralComponent>;
+
+  const createFixture = ({
+    isNew = false,
+    isDraft = false,
+    encryption = 'aes',
+    operationType = 'Backup',
+  }: {
+    isNew?: boolean;
+    isDraft?: boolean;
+    encryption?: string;
+    operationType?: OperationType;
+  } = {}) => {
+    const generalForm = createGeneralForm({
+      name: 'Imported backup',
+      description: '',
+      encryption,
+      password: encryption === NONE_OPTION.Key ? '' : 'secret',
+      repeatPassword: encryption === NONE_OPTION.Key ? '' : 'secret',
+      compression: '',
+      operationType,
+    });
+
+    TestBed.configureTestingModule({
+      imports: [GeneralComponent],
+      providers: [
+        { provide: Router, useValue: { navigate: vi.fn() } },
+        { provide: ActivatedRoute, useValue: { parent: {} } },
+        {
+          provide: PasswordGeneratorService,
+          useValue: { calculatePasswordStrength: vi.fn(() => 4), generate: vi.fn(() => 'generated') },
+        },
+        { provide: SysinfoState, useValue: { hasSyncMode: signal(true) } },
+        {
+          provide: BackupState,
+          useValue: {
+            generalForm,
+            generalFormSignal: signal(generalForm.getRawValue()),
+            encryptionFieldSignal: signal(encryption),
+            operationTypeFieldSignal: signal(operationType),
+            encryptionOptions: signal([NONE_OPTION, { Key: 'aes', DisplayName: 'AES' }]),
+            isNew: signal(isNew),
+            isDraft: signal(isDraft),
+            shouldAutoSave: signal(false),
+            submit: vi.fn(),
+            exit: vi.fn(),
+          },
+        },
+      ],
+    });
+
+    fixture = TestBed.createComponent(GeneralComponent);
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  };
+
+  afterEach(() => {
+    fixture?.destroy();
+    TestBed.resetTestingModule();
+  });
+
+  it('shows encryption and password fields for an encrypted import draft', () => {
+    const element = createFixture({ isDraft: true });
+
+    expect(element.querySelector('sh-select')).not.toBeNull();
+    expect(element.querySelector('#password')).not.toBeNull();
+    expect(element.querySelector('#repeatPassword')).not.toBeNull();
+    expect(element.textContent).not.toContain('Encrypted backup');
+  });
+
+  it('shows the encryption selector without password fields for an unencrypted import draft', () => {
+    const element = createFixture({ isDraft: true, encryption: NONE_OPTION.Key });
+
+    expect(element.querySelector('sh-select')).not.toBeNull();
+    expect(element.querySelector('#password')).toBeNull();
+    expect(element.querySelector('#repeatPassword')).toBeNull();
+  });
+
+  it('keeps encryption fields hidden for an existing backup', () => {
+    const element = createFixture();
+
+    expect(element.querySelector('sh-select')).toBeNull();
+    expect(element.querySelector('#password')).toBeNull();
+    expect(element.textContent).toContain('Encrypted backup');
+  });
+
+  it('keeps encryption fields available for a new backup', () => {
+    const element = createFixture({ isNew: true });
+
+    expect(element.querySelector('sh-select')).not.toBeNull();
+    expect(element.querySelector('#password')).not.toBeNull();
+  });
+
+  it('does not show encryption fields for an imported sync job', () => {
+    const element = createFixture({ isDraft: true, operationType: 'Sync' });
+
+    expect(element.querySelector('sh-select')).toBeNull();
+    expect(element.querySelector('#password')).toBeNull();
+    expect(element.textContent).toContain('Synchronization job - files are not encrypted');
+  });
+});

--- a/projects/ngclient/src/app/backup/general/general.component.ts
+++ b/projects/ngclient/src/app/backup/general/general.component.ts
@@ -88,6 +88,8 @@ export default class GeneralComponent {
   operationTypeFieldSignal = signal<OperationType>('Backup'); // this.#backupState.operationTypeFieldSignal;
   encryptionOptions = this.#backupState.encryptionOptions;
   isNew = this.#backupState.isNew;
+  isDraft = this.#backupState.isDraft;
+  canEditEncryption = computed(() => this.isNew() || this.isDraft());
   syncModeSupported = this.#sysinfo.hasSyncMode;
 
   showPassword = signal(false);


### PR DESCRIPTION
## Summary

- allow imported backup drafts to edit their encryption method and passphrase
- normalize imported encryption setting names, including optional `--` prefixes and casing
- map an enabled `no-encryption` option to the existing None selection

## Root cause

Non-direct imports are opened with a generated draft ID. This makes `isNew()` false, so the General step treated the draft like an existing saved backup and rendered only the encryption summary instead of the encryption and passphrase fields.

Imported drafts can now edit encryption settings while ordinary existing backups remain unchanged. Direct imports, import DTOs, and persisted backup settings are not changed.

## Validation

- `bun install --frozen-lockfile`
- `bun x prettier --check` for all changed files
- focused unit and component tests — 2 files, 13 tests passed
- `bun run test:ci` — 12 files, 73 tests passed
- `bun run gen:font`
- `bun x ng build ngclient --configuration production`

The component tests cover encrypted and unencrypted drafts, existing backups, new backups, and imported sync jobs. The settings tests cover prefixed and unprefixed names, casing, passphrases, and supported boolean values for `no-encryption`.

Fixes duplicati/duplicati#7110
