### PR TITLE
Align usage statistics settings across UIs

### DIFF
--- a/projects/ngclient/src/app/settings/settings.component.ts
+++ b/projects/ngclient/src/app/settings/settings.component.ts
@@ -28,6 +28,12 @@ import { CreateSignalOptions, WritableSignal } from '@angular/core';
 import { createSignal, SIGNAL, SignalGetter, signalSetFn, signalUpdateFn } from '@angular/core/primitives/signals';
 import { ConfirmDialogComponent } from '../core/components/confirm-dialog/confirm-dialog.component';
 import { RelayconfigState } from '../core/states/relayconfig.state';
+import {
+  toUsageReporterLevel,
+  toUsageStatisticsControlValue,
+  USAGE_STATISTICS_OPTIONS,
+  UsageStatisticsControlValue,
+} from './usage-statistics-settings';
 
 export function debounceSignal<T>(initialValue: T, time: number, options?: CreateSignalOptions<T>): WritableSignal<T> {
   const [getter] = createSignal<T>(initialValue, options?.equal);
@@ -77,35 +83,6 @@ const TIME_OPTIONS = [
 
 type TimeTypes = (typeof TIME_OPTIONS)[number]['value'];
 
-const USAGE_STATISTICS_OPTIONS = [
-  {
-    value: 'none',
-    label: $localize`System default ($value)`,
-  },
-  {
-    value: 'information',
-    label: $localize`Usage statistics, warnings, errors, and crashes`,
-  },
-  {
-    value: 'warning',
-    label: $localize`Warnings, errors and crashes`,
-  },
-  {
-    value: 'error',
-    label: $localize`Errors and crashes`,
-  },
-  {
-    value: 'crash',
-    label: $localize`Crashes only`,
-  },
-  {
-    value: 'disabled',
-    label: $localize`None / disabled`,
-  },
-];
-
-type UsageStatisticsType = (typeof USAGE_STATISTICS_OPTIONS)[number];
-
 @Component({
   selector: 'app-settings',
   imports: [
@@ -148,7 +125,7 @@ export default class SettingsComponent {
   previousLang = this.#initLang;
   langCtrl = signal<string>(this.#initLang);
   powerModeCtrl = signal<string>('');
-  usageStatistics = signal<UsageStatisticsType['value']>('');
+  usageStatistics = signal<UsageStatisticsControlValue>('default');
   updatingUsageStatistics = signal(false);
   remoteControlStatus = this.#remoteControlState.statusMessage;
   remoteControlState = this.#remoteControlState.state;
@@ -371,15 +348,15 @@ export default class SettingsComponent {
     }, 1000);
   }
 
-  updateUsageStatistics(newUsageStatistics: string) {
+  updateUsageStatistics(newUsageStatistics: UsageStatisticsControlValue) {
     const previousUsageStatistics = this.usageStatistics();
 
-    if (!newUsageStatistics || newUsageStatistics === '' || newUsageStatistics === previousUsageStatistics) return;
+    if (newUsageStatistics === previousUsageStatistics) return;
 
     this.usageStatistics.set(newUsageStatistics);
     this.updatingUsageStatistics.set(true);
 
-    this.#serverSettingsService.setUsageReporterLevel(newUsageStatistics).subscribe();
+    this.#serverSettingsService.setUsageReporterLevel(toUsageReporterLevel(newUsageStatistics)).subscribe();
   }
 
   updatePowerMode(newPowerMode: string) {
@@ -406,9 +383,7 @@ export default class SettingsComponent {
     this.allowedHostnames.set(serverSettings['allowed-hostnames']);
     this.loadedAllowedHostnames.set(serverSettings['allowed-hostnames']);
     this.consoleControlDisabled.set(serverSettings['disable-console-control'] === 'True' ? true : false);
-    this.usageStatistics.set(
-      serverSettings['usage-reporter-level'] === '' ? 'none' : serverSettings['usage-reporter-level']
-    );
+    this.usageStatistics.set(toUsageStatisticsControlValue(serverSettings['usage-reporter-level']));
 
     this.timeType.set(startupDelay == '' ? 'none' : timeUnitOptions.includes(unit) ? unit : 'none');
     this.timeValue.set(startupDelay == '' ? 0 : parseInt(timeStr));

--- a/projects/ngclient/src/app/settings/usage-statistics-settings.spec.ts
+++ b/projects/ngclient/src/app/settings/usage-statistics-settings.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  toUsageReporterLevel,
+  toUsageStatisticsControlValue,
+  USAGE_STATISTICS_OPTIONS,
+  UsageStatisticsControlValue,
+} from './usage-statistics-settings';
+
+describe('usage statistics settings', () => {
+  it.each<[string | null | undefined, UsageStatisticsControlValue]>([
+    ['', 'default'],
+    ['   ', 'default'],
+    [null, 'default'],
+    [undefined, 'default'],
+    ['unknown', 'default'],
+    ['information', 'information'],
+    [' WARNING ', 'warning'],
+    ['Error', 'error'],
+    ['CRASH', 'crash'],
+    ['none', 'none'],
+    [' Disabled ', 'none'],
+  ])('maps server value %s to control value %s', (serverValue, controlValue) => {
+    expect(toUsageStatisticsControlValue(serverValue)).toBe(controlValue);
+  });
+
+  it.each<[UsageStatisticsControlValue, string]>([
+    ['default', ''],
+    ['information', 'information'],
+    ['warning', 'warning'],
+    ['error', 'error'],
+    ['crash', 'crash'],
+    ['none', 'none'],
+  ])('maps control value %s to server value %s', (controlValue, serverValue) => {
+    expect(toUsageReporterLevel(controlValue)).toBe(serverValue);
+  });
+
+  it('keeps system default and disabled as distinct options with their existing labels', () => {
+    expect(USAGE_STATISTICS_OPTIONS.map(({ value }) => value)).toEqual([
+      'default',
+      'information',
+      'warning',
+      'error',
+      'crash',
+      'none',
+    ]);
+    expect(USAGE_STATISTICS_OPTIONS[0].label).toBe('System default ($value)');
+    expect(USAGE_STATISTICS_OPTIONS.at(-1)?.label).toBe('None / disabled');
+  });
+});

--- a/projects/ngclient/src/app/settings/usage-statistics-settings.ts
+++ b/projects/ngclient/src/app/settings/usage-statistics-settings.ts
@@ -1,0 +1,43 @@
+export type UsageStatisticsControlValue = 'default' | 'information' | 'warning' | 'error' | 'crash' | 'none';
+
+export const USAGE_STATISTICS_OPTIONS: { value: UsageStatisticsControlValue; label: string }[] = [
+  {
+    value: 'default',
+    label: $localize`System default ($value)`,
+  },
+  {
+    value: 'information',
+    label: $localize`Usage statistics, warnings, errors, and crashes`,
+  },
+  {
+    value: 'warning',
+    label: $localize`Warnings, errors and crashes`,
+  },
+  {
+    value: 'error',
+    label: $localize`Errors and crashes`,
+  },
+  {
+    value: 'crash',
+    label: $localize`Crashes only`,
+  },
+  {
+    value: 'none',
+    label: $localize`None / disabled`,
+  },
+];
+
+const REPORTING_LEVELS = new Set<UsageStatisticsControlValue>(['information', 'warning', 'error', 'crash', 'none']);
+
+export const toUsageStatisticsControlValue = (value: string | null | undefined): UsageStatisticsControlValue => {
+  const normalizedValue = (value ?? '').trim().toLowerCase();
+
+  if (normalizedValue === 'disabled') return 'none';
+  if (REPORTING_LEVELS.has(normalizedValue as UsageStatisticsControlValue)) {
+    return normalizedValue as UsageStatisticsControlValue;
+  }
+
+  return 'default';
+};
+
+export const toUsageReporterLevel = (value: UsageStatisticsControlValue) => (value === 'default' ? '' : value);


### PR DESCRIPTION
## Summary

- align the usage statistics selector with the value format used by the legacy UI and server settings
- represent the system default with an internal `default` value while persisting it as an empty string
- persist opt-out as `none` and continue to recognize the earlier ngclient-specific `disabled` value

## Root cause

The legacy UI stores an empty string for the system default and `none` for disabled reporting. ngclient instead used `none` for the system default and `disabled` for disabled reporting, so each UI misrepresented values written by the other.

The conversion is now explicit in both directions. Existing `disabled` values are displayed as disabled for compatibility, but opening the settings page does not rewrite them automatically. Future explicit selections use the canonical legacy-compatible values.

## Validation

- `bun install --frozen-lockfile`
- `bunx prettier --check projects/ngclient/src/app/settings/settings.component.ts projects/ngclient/src/app/settings/usage-statistics-settings.ts projects/ngclient/src/app/settings/usage-statistics-settings.spec.ts`
- targeted Vitest spec: 18 tests passed
- `bun run test:ci`: 11 test files and 78 tests passed
- `bun run gen:font`
- `bunx ng build ngclient --configuration production`

Fixes duplicati/duplicati#7121
