### PR TITLE
Fix Chinese locale selection

### DIFF
--- a/projects/ngclient/src/app/core/locales/locales.utility.spec.ts
+++ b/projects/ngclient/src/app/core/locales/locales.utility.spec.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_LOCALE, getLocale, LANGUAGES, mapLocale, resolveLocale } from './locales.utility';
+
+describe('locale utilities', () => {
+  afterEach(() => {
+    localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it.each(LANGUAGES.map(({ value }) => [value]))('accepts the selectable locale %s', (locale) => {
+    expect(resolveLocale(locale)).toBe(locale);
+  });
+
+  it.each([
+    ['zh-CN', 'zh'],
+    ['zh-TW', 'zh-TW'],
+    ['zh-HK', 'zh-HK'],
+    ['ja-JP', 'ja'],
+  ])('maps %s to the existing %s translation locale', (locale, mappedLocale) => {
+    expect(mapLocale(locale)).toBe(mappedLocale);
+  });
+
+  it.each([null, undefined, '', 'unsupported-locale'])('falls back to the default locale for %s', (locale) => {
+    expect(resolveLocale(locale)).toBe(DEFAULT_LOCALE);
+  });
+
+  it('loads the Simplified Chinese translations for a saved zh-CN selection', async () => {
+    const json = vi.fn().mockResolvedValue({ translations: {} });
+    const fetchMock = vi.fn().mockResolvedValue({ json });
+    vi.stubGlobal('fetch', fetchMock);
+    localStorage.setItem('v1:duplicati:locale', 'zh-CN');
+
+    expect(getLocale()).toBe('zh-CN');
+    expect(fetchMock).toHaveBeenCalledWith('locale/messages.zh.json');
+
+    await vi.waitFor(() => expect(json).toHaveBeenCalled());
+  });
+});

--- a/projects/ngclient/src/app/core/locales/locales.utility.ts
+++ b/projects/ngclient/src/app/core/locales/locales.utility.ts
@@ -215,8 +215,13 @@ export const ANGULAR_MJS_LOCALE_MAP: Record<string, string> = {
   'zh-HK': 'zh-Hant',
 };
 
-const SUPPORTED_LOCALES = Array.from(new Set(Object.values(LOCALE_MAP)));
-type Locales = (typeof SUPPORTED_LOCALES)[number];
+const SUPPORTED_LOCALES = new Set(Object.keys(LOCALE_MAP));
+type Locales = string;
+
+export function resolveLocale(locale: string | null | undefined): Locales {
+  const requestedLocale = locale || DEFAULT_LOCALE;
+  return SUPPORTED_LOCALES.has(requestedLocale) ? requestedLocale : DEFAULT_LOCALE;
+}
 
 export function mapLocale(locale: string | null | undefined) {
   if (!locale) return 'en';
@@ -226,7 +231,7 @@ export function mapLocale(locale: string | null | undefined) {
 
 export function getLocale(): Locales {
   const appLang = localStorage.getItem('v1:duplicati:locale') || DEFAULT_LOCALE;
-  const locale = SUPPORTED_LOCALES.find((x) => x === appLang) ?? DEFAULT_LOCALE;
+  const locale = resolveLocale(appLang);
 
   // Try to resolve the mapped locale, falling back to base language
   const mappedLocale =


### PR DESCRIPTION
## Summary

- accept every locale ID exposed by Settings before mapping it to translation resources
- keep selections such as `zh-CN` and `ja-JP` intact instead of falling back to `en-US`
- preserve the existing translation-file and Angular locale mappings, including `zh-CN` to the Simplified Chinese `zh` resources

## Root cause

The supported-locale check was built from the mapped resource locale values rather than from the accepted input locale IDs. As a result, selectable aliases whose IDs differ from their resource mapping—such as `zh-CN` -> `zh` and `ja-JP` -> `ja`—were treated as unsupported.

## Compatibility

Unknown or empty locale values still fall back to `en-US`. Translation JSON files, stored locale values, request headers, and backend APIs are unchanged.

## Visual verification

<img width="1280" height="720" alt="Settings showing Simplified Chinese with Chinese (zh-CN) selected" src="https://github.com/user-attachments/assets/6b4bfa40-d410-4826-b1c1-89cae08d0a2d" />

The selected `Chinese (zh-CN)` locale remains visible after reloading, and the interface uses the existing Simplified Chinese translations.

## Validation

- `bun install --frozen-lockfile`
- Prettier check for the changed files
- locale utility tests: 42 passed
- full Vitest suite: 102 passed
- `bun run gen:font`
- `bunx ng build ngclient --configuration production`
- confirmed `messages.zh.json`, `messages.zh_CN.json`, and `messages.zh_TW.json` are present in the production output
- manually selected `zh-CN` in Settings, confirmed the UI switched to Simplified Chinese, reloaded and confirmed both the language and selection persisted, then switched back to `en-US`

Fixes duplicati/duplicati#7125
