### PR TITLE
Normalize WebDAV destination paths

### DIFF
--- a/projects/ngclient/src/app/backup/destination/destination.config.ts
+++ b/projects/ngclient/src/app/backup/destination/destination.config.ts
@@ -1554,7 +1554,8 @@ export const DESTINATION_CONFIG: DestinationConfig = [
     mapper: {
       to: (fields: ValueOfDestinationFormGroup): string => {
         const { server, port, path } = fields.custom;
-        return buildUrlFromFields(fields, server, port, path);
+        const normalizedPath = typeof path === 'string' ? path.replace(/^\/+/, '') : path;
+        return buildUrlFromFields(fields, server, port, normalizedPath);
       },
       from: (destinationType: string, urlObj: UrlLike, plainPath: string) => {
         const { server, port, path } = fromUrlObj(urlObj);

--- a/projects/ngclient/src/app/backup/destination/destination.webdav-mapper.spec.ts
+++ b/projects/ngclient/src/app/backup/destination/destination.webdav-mapper.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import {
+  fromTargetPath,
+  getConfigurationByKey,
+  UrlLike,
+  type ValueOfDestinationFormGroup,
+} from './destination.config-utilities';
+
+const webdav = getConfigurationByKey('webdav');
+
+function webdavFields(path: string, port: string | null = '443'): ValueOfDestinationFormGroup {
+  return {
+    destinationType: 'webdav',
+    custom: {
+      server: 'webdav.example.com',
+      port,
+      path,
+    },
+    advanced: {
+      'debug-propfind-file': 'trace file.txt',
+    },
+    dynamic: {
+      'use-ssl': true,
+      'auth-username': 'user name',
+      'auth-password': 'secret',
+    },
+  } as ValueOfDestinationFormGroup;
+}
+
+describe('WebDAV destination mapper', () => {
+  it.each(['/Sicherung/nuc/config', 'Sicherung/nuc/config', '///Sicherung/nuc/config'])(
+    'normalizes the leading slash in %s',
+    (path) => {
+      const targetUrl = webdav.mapper.to(webdavFields(path));
+
+      expect(targetUrl).not.toContain(':443//');
+      expect(new UrlLike(targetUrl).pathname).toBe('/Sicherung/nuc/config');
+    }
+  );
+
+  it('round-trips an existing valid URL without changing its path', () => {
+    const targetUrl =
+      'webdav://webdav.example.com:443/Sicherung/nuc/config?debug-propfind-file=trace%20file.txt&use-ssl=true&auth-username=user%20name&auth-password=secret';
+    const fields = fromTargetPath(targetUrl);
+
+    expect(fields).not.toBeNull();
+    const result = new UrlLike(webdav.mapper.to(fields!));
+
+    expect(result.host).toBe('webdav.example.com:443');
+    expect(result.pathname).toBe('/Sicherung/nuc/config');
+    expect(Object.fromEntries(result.searchParams)).toEqual({
+      'debug-propfind-file': 'trace file.txt',
+      'use-ssl': 'true',
+      'auth-username': 'user name',
+      'auth-password': 'secret',
+    });
+  });
+
+  it('repairs a double-slash URL when it is loaded and saved again', () => {
+    const fields = fromTargetPath(
+      'webdav://webdav.example.com:443//Sicherung/nuc/config?use-ssl=true&auth-username=user&auth-password=secret'
+    );
+
+    expect(fields).not.toBeNull();
+    const result = webdav.mapper.to(fields!);
+
+    expect(result).not.toContain(':443//');
+    expect(new UrlLike(result).pathname).toBe('/Sicherung/nuc/config');
+  });
+
+  it('preserves an empty path and omitted port', () => {
+    expect(webdav.mapper.to(webdavFields('', null))).toBe(
+      'webdav://webdav.example.com?debug-propfind-file=trace%20file.txt&use-ssl=true&auth-username=user%20name&auth-password=secret'
+    );
+  });
+
+  it('does not change the absolute-path semantics of alternative FTP', () => {
+    const aftp = getConfigurationByKey('aftp');
+    const fields = {
+      destinationType: 'aftp',
+      custom: {
+        server: 'ftp.example.com',
+        port: null,
+        path: '/absolute/path',
+      },
+      advanced: {},
+      dynamic: {},
+    } as ValueOfDestinationFormGroup;
+
+    expect(aftp.mapper.to(fields)).toBe('aftp://ftp.example.com//absolute/path');
+  });
+});


### PR DESCRIPTION
## Summary

- normalize leading slashes before the WebDAV destination mapper serializes its path
- repair existing double-slash WebDAV URLs the next time they are loaded and saved
- add focused mapper regression tests for URL round-tripping and backend-specific path semantics

## Root cause

The WebDAV editor accepts a path that may begin with `/`, while the shared URL builder also inserts the separator between the server and path. Serializing such a value therefore produced `host:port//path`. Loading an already affected URL left one leading slash in the form value, so saving it repeated the problem.

The normalization is intentionally limited to the WebDAV mapper. The shared `concatPaths`, `buildUrl`, and `removeLeadingSlash` helpers are unchanged because a double slash represents an absolute path for backends such as Alternative FTP.

## Tests

- leading slash, no leading slash, and repeated leading slash WebDAV paths serialize identically
- a valid WebDAV URL round-trips without changing its path, port, credentials, SSL, or advanced options
- an existing double-slash URL is repaired when loaded and serialized again
- empty paths and omitted ports retain their current format
- Alternative FTP retains its existing absolute-path double-slash behavior

## Validation

- `bun install --frozen-lockfile`
- Prettier check for the changed files
- focused WebDAV mapper suite: 7 passed
- full Vitest suite: 24 files, 248 tests passed
- `bun run gen:font`
- `bunx ng build ngclient --configuration production`

Fixes duplicati/duplicati#7188
