### PR TITLE
Preserve folder filter type while editing

### DIFF
--- a/projects/ngclient/src/app/backup/source-data/new-filter/new-filter.component.spec.ts
+++ b/projects/ngclient/src/app/backup/source-data/new-filter/new-filter.component.spec.ts
@@ -1,0 +1,108 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { afterEach, describe, expect, it } from 'vitest';
+import { NewFilterComponent, parseFilterPath, serializeFilterPath } from './new-filter.component';
+
+describe('new filter path conversion', () => {
+  it.each([
+    ['-/home/user/', undefined, '-Folder', '/home/user'],
+    ['+C:\\Data\\Backups\\', 'Windows', '+Folder', 'C:\\Data\\Backups'],
+    ['-%HOME%/', undefined, '-Folder', '%HOME%'],
+    ['-/', undefined, '-Folder', '/'],
+    ['-C:\\', 'Windows', '-Folder', 'C:\\'],
+  ])('parses %s as a folder without exposing its syntax delimiter', (path, osType, type, expression) => {
+    expect(parseFilterPath(path, osType)).toEqual({ type, expression });
+  });
+
+  it.each([
+    ['-*cache*/', '-FolderName', 'cache'],
+    ['-[.*temp[^\\/]*]', '-FileName', 'temp'],
+    ['-{DefaultExcludes}', '-FileGroup', 'DefaultExcludes'],
+    ['+[^important$]', '+Regex', '^important$'],
+    ['-*.tmp', '-Extension', 'tmp'],
+    ['-logs/*.tmp', '-Expression', 'logs/*.tmp'],
+  ])('keeps the existing parsing behavior for %s', (path, type, expression) => {
+    expect(parseFilterPath(path)).toEqual({ type, expression });
+  });
+
+  it.each([
+    ['-Folder', '/home/user', undefined, '-/home/user/'],
+    ['+Folder', 'C:\\Data\\Backups', 'Windows', '+C:\\Data\\Backups\\'],
+    ['-Folder', '%HOME%', undefined, '-%HOME%/'],
+    ['-Folder', '/home/user///', undefined, '-/home/user/'],
+    ['+Folder', 'C:\\Data\\Backups\\\\', 'Windows', '+C:\\Data\\Backups\\'],
+  ] as const)('serializes %s paths with one trailing delimiter', (type, expression, osType, expected) => {
+    expect(serializeFilterPath(type, expression, osType)).toBe(expected);
+  });
+
+  it('keeps non-folder affixes unchanged', () => {
+    expect(serializeFilterPath('-Expression', '*.tmp')).toBe('-*.tmp');
+    expect(serializeFilterPath('+Regex', 'important', undefined, '[', ']')).toBe('+[important]');
+  });
+});
+
+describe('NewFilterComponent folder editing', () => {
+  let fixture: ComponentFixture<NewFilterComponent>;
+
+  const createFixture = (path: string, osType?: string) => {
+    TestBed.configureTestingModule({ imports: [NewFilterComponent] });
+    fixture = TestBed.createComponent(NewFilterComponent);
+    fixture.componentRef.setInput('path', path);
+    fixture.componentRef.setInput('osType', osType);
+    fixture.detectChanges();
+
+    return fixture.componentInstance;
+  };
+
+  afterEach(() => {
+    fixture?.destroy();
+    TestBed.resetTestingModule();
+  });
+
+  it('keeps an excluded folder selected while its path is edited', () => {
+    const component = createFixture('-/srv/backups');
+    let emittedPath = '';
+    component.pathChange.subscribe((path) => (emittedPath = path));
+
+    component.pathType.set('-Folder');
+    component.internalPath.set('/srv/backups/archive');
+    component.updateFilter();
+
+    expect(emittedPath).toBe('-/srv/backups/archive/');
+
+    fixture.componentRef.setInput('path', emittedPath);
+    fixture.detectChanges();
+
+    expect(component.pathType()).toBe('-Folder');
+    expect(component.internalPath()).toBe('/srv/backups/archive');
+  });
+
+  it('keeps an included Windows folder selected while its path is edited', () => {
+    const component = createFixture('+C:\\Data', 'Windows');
+    let emittedPath = '';
+    component.pathChange.subscribe((path) => (emittedPath = path));
+
+    component.pathType.set('+Folder');
+    component.internalPath.set('C:\\Data\\Documents');
+    component.updateFilter();
+
+    expect(emittedPath).toBe('+C:\\Data\\Documents\\');
+
+    fixture.componentRef.setInput('path', emittedPath);
+    fixture.detectChanges();
+
+    expect(component.pathType()).toBe('+Folder');
+    expect(component.internalPath()).toBe('C:\\Data\\Documents');
+  });
+
+  it('does not change an expression filter while editing', () => {
+    const component = createFixture('-logs/*.lock');
+    let emittedPath = '';
+    component.pathChange.subscribe((path) => (emittedPath = path));
+
+    component.internalPath.set('logs/*.tmp');
+    component.updateFilter();
+
+    expect(emittedPath).toBe('-logs/*.tmp');
+    expect(component.pathType()).toBe('-Expression');
+  });
+});

--- a/projects/ngclient/src/app/backup/source-data/new-filter/new-filter.component.ts
+++ b/projects/ngclient/src/app/backup/source-data/new-filter/new-filter.component.ts
@@ -29,7 +29,7 @@ type _ExpressionType =
   | 'File'
   | 'Unknown';
 
-type ExpressionType = `${ExpressionDirection}${_ExpressionType}`;
+export type ExpressionType = `${ExpressionDirection}${_ExpressionType}`;
 type ExpressionTypeMap = {
   key: string;
   value: ExpressionType;
@@ -137,6 +137,87 @@ const EXPRESSION_OPTIONS: ExpressionTypeMap[] = [
   },
 ] as const;
 
+export type ParsedFilterPath = {
+  type: ExpressionType;
+  expression: string;
+};
+
+const getPathDelimiter = (osType?: string) => (osType === 'Windows' ? '\\' : '/');
+
+const removeFolderSyntaxDelimiter = (path: string, pathDelimiter: string) => {
+  let normalizedPath = path;
+
+  while (
+    normalizedPath.endsWith(pathDelimiter) &&
+    normalizedPath !== pathDelimiter &&
+    !/^[A-Za-z]:\\$/.test(normalizedPath)
+  ) {
+    normalizedPath = normalizedPath.slice(0, -1);
+  }
+
+  return normalizedPath;
+};
+
+export const parseFilterPath = (path: string, osType?: string): ParsedFilterPath => {
+  const expression = path.slice(1);
+  const direction: ExpressionDirection = path.startsWith('-') ? '-' : '+';
+  const pathDelimiter = getPathDelimiter(osType);
+  const isWindows = osType === 'Windows';
+  const isShortCut = expression.startsWith('%');
+
+  if (
+    (isShortCut && expression.endsWith(pathDelimiter)) ||
+    (isWindows && expression.slice(2).startsWith(pathDelimiter) && expression.endsWith(pathDelimiter)) ||
+    (expression.startsWith(pathDelimiter) && expression.endsWith(pathDelimiter))
+  ) {
+    return {
+      type: `${direction}Folder`,
+      expression: removeFolderSyntaxDelimiter(expression, pathDelimiter),
+    };
+  }
+
+  if (expression.startsWith('*') && expression.endsWith(`*${pathDelimiter}`)) {
+    return { type: `${direction}FolderName`, expression: expression.slice(1, -2) };
+  }
+
+  if (expression.startsWith('[.*') && expression.endsWith(`[^\\${pathDelimiter}]*]`)) {
+    return { type: `${direction}FileName`, expression: expression.slice(3, -7) };
+  }
+
+  if (expression.startsWith('{') && expression.endsWith('}')) {
+    return { type: `${direction}FileGroup`, expression: expression.slice(1, -1) };
+  }
+
+  if (expression.startsWith('[') && expression.endsWith(']')) {
+    return { type: `${direction}Regex`, expression: expression.slice(1, -1) };
+  }
+
+  if (expression.startsWith('*.')) {
+    return { type: `${direction}Extension`, expression: expression.slice(2) };
+  }
+
+  return { type: `${direction}Expression`, expression };
+};
+
+export const serializeFilterPath = (
+  type: ExpressionType,
+  expression: string,
+  osType?: string,
+  startsWith = '',
+  endsWith = ''
+) => {
+  const direction = type.slice(0, 1);
+
+  if (type.endsWith('Folder')) {
+    const pathDelimiter = getPathDelimiter(osType);
+    const normalizedExpression = removeFolderSyntaxDelimiter(expression, pathDelimiter);
+
+    return `${direction}${normalizedExpression}${normalizedExpression.endsWith(pathDelimiter) ? '' : pathDelimiter}`;
+  }
+
+  return `${direction}${startsWith}${expression}${endsWith}`;
+};
+
 @Component({
   selector: 'app-new-filter',
   imports: [FormsModule, ShipSelect, ShipFormField, ShipIcon],
@@ -217,38 +298,10 @@ export class NewFilterComponent {
 
   pathEffect = effect(() => {
     const newPath = this.path();
-    const x = newPath.slice(1);
-    const direction = newPath.startsWith('-') ? '-' : '+';
-    const isWindows = this.osType() === 'Windows';
-    const pathDelimiter = isWindows ? '\\' : '/';
-    const isShortCut = x.startsWith('%');
+    const parsedPath = parseFilterPath(newPath, this.osType());
 
-    if (
-      (isShortCut && x.endsWith(pathDelimiter)) ||
-      (isWindows && x.slice(2).startsWith(pathDelimiter) && x.endsWith(pathDelimiter)) ||
-      (x.startsWith(pathDelimiter) && x.endsWith(pathDelimiter))
-    ) {
-      this.pathType.set(`${direction}Folder`);
-      this.internalPath.set(x);
-    } else if (x.startsWith('*') && x.endsWith(`*${pathDelimiter}`)) {
-      this.pathType.set(`${direction}FolderName`);
-      this.internalPath.set(x.slice(1, -2));
-    } else if (x.startsWith('[.*') && x.endsWith(`[^\\${pathDelimiter}]*]`)) {
-      this.pathType.set(`${direction}FileName`);
-      this.internalPath.set(x.slice(3, -7));
-    } else if (x.startsWith('{') && x.endsWith('}')) {
-      this.pathType.set(`${direction}FileGroup`);
-      this.internalPath.set(x.slice(1, -1));
-    } else if (x.startsWith('[') && x.endsWith(']')) {
-      this.pathType.set(`${direction}Regex`);
-      this.internalPath.set(x.slice(1, -1));
-    } else if (x.startsWith('*.')) {
-      this.pathType.set(`${direction}Extension`);
-      this.internalPath.set(x.slice(2));
-    } else {
-      this.pathType.set(`${direction}Expression`);
-      this.internalPath.set(x);
-    }
+    this.pathType.set(parsedPath.type);
+    this.internalPath.set(parsedPath.expression);
 
     // Focus the input if this is a newly added filter
     if (this.isNew()) {
@@ -278,8 +331,16 @@ export class NewFilterComponent {
       newPath = '';
     }
 
+    if (!expressionOption) return;
+
     this.pathChange.emit(
-      `${expressionOption?.value.slice(0, 1)}${expressionOption?.startsWith ?? ''}${newPath}${expressionOption?.endsWith ?? ''}`
+      serializeFilterPath(
+        expressionOption.value,
+        newPath,
+        this.osType(),
+        expressionOption.startsWith,
+        expressionOption.endsWith
+      )
     );
   }
 


### PR DESCRIPTION
## Summary

- append the platform-specific trailing delimiter when folder filters are serialized
- keep Duplicati's folder syntax delimiter out of the editable path value
- preserve the selected Include/Exclude Folder type while the parent component receives and returns each edit

## Root cause

Folder options intentionally have no visible prefix or suffix in the editor, but the same empty affixes were also used when serializing the filter. The parent therefore received a path without Duplicati's trailing folder delimiter. When that value was passed back to the row component, it was parsed as a generic expression and the selected folder type was lost.

The fix separates parsing and serialization from the UI affixes. Folder filters now receive exactly one `/` or `\\` delimiter according to the source OS, while the input continues to show a normal path without requiring users to manage that syntax themselves. Other filter formats and the bulk text representation are unchanged.

## Tests

- Unix, Windows, shortcut, root, and repeated-delimiter folder paths
- Include and Exclude Folder serialization
- parent input/output round-trips while continuing to edit a folder
- existing folder-name, file-name, file-group, regex, extension, and expression parsing

## Validation

- `bun install --frozen-lockfile`
- Prettier check for the changed files
- focused suite: 20 tests passed
- full Vitest suite: 25 files, 264 tests passed
- `bun run gen:font`
- `bunx ng build ngclient --configuration production`

Fixes #468

Part of #273
