### PR TITLE
Add translatable run script status

### DIFF
--- a/projects/ngclient/src/app/core/components/status-bar/status-bar.state.ts
+++ b/projects/ngclient/src/app/core/components/status-bar/status-bar.state.ts
@@ -1,7 +1,7 @@
 import { computed, effect, inject, Injectable, signal } from '@angular/core';
 import { ShipDialogService } from '@ship-ui/core/ship-dialog';
 import { finalize, map, of, switchMap } from 'rxjs';
-import { STATUS_STATES } from '../../constants/status-states.constant';
+import { resolveStatusText, STATUS_STATES } from '../../constants/status-states.constant';
 import {
   DuplicatiServer,
   GetApiV1ProgressstateResponse,
@@ -292,7 +292,7 @@ export class StatusBarState {
     let text = 'Running …';
 
     if (status.task && status) {
-      text = status.Phase ? (STATUS_STATES[status.Phase] ?? status.Phase) : 'Running …';
+      text = resolveStatusText(status.Phase, 'Running …');
 
       // If there is nothing to process, just return the base text
       // This happens during the initial phases of a backup/restore

--- a/projects/ngclient/src/app/core/constants/status-states.constant.spec.ts
+++ b/projects/ngclient/src/app/core/constants/status-states.constant.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { resolveStatusText, STATUS_STATES } from './status-states.constant';
+
+describe('status text resolution', () => {
+  it('maps the run script phase to a translatable message', () => {
+    expect(STATUS_STATES['RunScript_Running']).toBe('Running script …');
+    expect(resolveStatusText('RunScript_Running')).toBe('Running script …');
+  });
+
+  it('continues to resolve existing known phases', () => {
+    expect(resolveStatusText('Backup_ProcessingFiles')).toBe('Processing files to backup …');
+  });
+
+  it('preserves unknown phases for forward compatibility', () => {
+    expect(resolveStatusText('FutureOperation_Running')).toBe('FutureOperation_Running');
+  });
+
+  it.each([null, undefined])('returns an empty string when %s has no fallback', (phase) => {
+    expect(resolveStatusText(phase)).toBe('');
+  });
+
+  it.each([null, undefined])('returns the caller fallback when %s has no phase', (phase) => {
+    expect(resolveStatusText(phase, 'Running …')).toBe('Running …');
+  });
+});

--- a/projects/ngclient/src/app/core/constants/status-states.constant.ts
+++ b/projects/ngclient/src/app/core/constants/status-states.constant.ts
@@ -59,6 +59,7 @@ export const STATUS_STATES: Record<string, string> = {
   Repair_Running: $localize`Repairing database …`,
   Verify_Running: $localize`Verifying files …`,
   BugReport_Running: $localize`Creating bug report …`,
+  RunScript_Running: $localize`Running script …`,
   Delete_Listing: $localize`Listing remote files …`,
   Delete_Deleting: $localize`Deleting remote files …`,
   PurgeFiles_Begin: $localize`Listing remote files for purge …`,
@@ -73,3 +74,6 @@ export const STATUS_STATES: Record<string, string> = {
   Sync_Complete: $localize`Sync complete!`,
   Error: $localize`Error!`,
 };
+
+export const resolveStatusText = (phase: string | null | undefined, fallback = '') =>
+  phase ? (STATUS_STATES[phase] ?? phase) : fallback;

--- a/projects/ngclient/src/app/status/status.component.ts
+++ b/projects/ngclient/src/app/status/status.component.ts
@@ -9,7 +9,7 @@ import { ShipProgressBar } from '@ship-ui/core/ship-progress-bar';
 import LogsLiveComponent from '../about/logs/logs-live/logs-live.component';
 import { PauseDialogComponent } from '../core/components/status-bar/pause-dialog/pause-dialog.component';
 import { StatusBarState } from '../core/components/status-bar/status-bar.state';
-import { STATUS_STATES } from '../core/constants/status-states.constant';
+import { resolveStatusText } from '../core/constants/status-states.constant';
 import { DuplicatiServer } from '../core/openapi';
 import { BytesPipe } from '../core/pipes/byte.pipe';
 import { RelativeTimePipe } from '../core/pipes/relative-time.pipe';
@@ -50,7 +50,7 @@ export default class StatusComponent implements OnInit, OnDestroy {
 
   statusText = computed(() => {
     const phase = this.statusData()?.Phase;
-    return phase ? STATUS_STATES[phase] || phase : '';
+    return resolveStatusText(phase);
   });
 
   progress = computed(() => {


### PR DESCRIPTION
## Summary

- map `RunScript_Running` to the translatable `Running script …` message used by the legacy UI
- share status phase resolution between the top status view and the status bar
- preserve raw unknown phases and each caller's existing empty-phase fallback

## Root cause

The backend added the `RunScript_Running` operation phase, but ngclient's status map did not include it. Both status displays therefore fell back to rendering the raw phase identifier.

The shared resolver keeps that forward-compatible fallback for genuinely unknown phases while allowing known phases to use localized text.

## Tests

- run-script and existing known phase mappings
- unknown phase passthrough
- null and undefined phases with the top-view and status-bar fallback behavior

## Validation

- `bun install --frozen-lockfile`
- Prettier check for the changed files
- focused suite: 7 tests passed
- full Vitest suite: 25 files, 251 tests passed
- `bun run gen:font`
- `bunx ng build ngclient --configuration production`

Fixes #503

Part of #273
