### PR TITLE
Add password and crypto utility tests

### DIFF
--- a/projects/ngclient/src/app/core/functions/crypto.spec.ts
+++ b/projects/ngclient/src/app/core/functions/crypto.spec.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRandomValues, randomUUID } from './crypto';
+
+const originalCryptoDescriptor = Object.getOwnPropertyDescriptor(window, 'crypto');
+const originalMsCryptoDescriptor = Object.getOwnPropertyDescriptor(window, 'msCrypto');
+
+const setWindowProperty = (name: 'crypto' | 'msCrypto', value: unknown) => {
+  Object.defineProperty(window, name, {
+    configurable: true,
+    value,
+  });
+};
+
+const restoreWindowProperty = (name: 'crypto' | 'msCrypto', descriptor?: PropertyDescriptor) => {
+  if (descriptor) {
+    Object.defineProperty(window, name, descriptor);
+  } else {
+    delete (window as unknown as Record<string, unknown>)[name];
+  }
+};
+
+describe('crypto utilities', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    restoreWindowProperty('crypto', originalCryptoDescriptor);
+    restoreWindowProperty('msCrypto', originalMsCryptoDescriptor);
+  });
+
+  it('uses the native randomUUID implementation when available', () => {
+    const nativeRandomUUID = vi.fn(() => '123e4567-e89b-42d3-a456-426614174000');
+    setWindowProperty('crypto', { randomUUID: nativeRandomUUID });
+
+    expect(randomUUID()).toBe('123e4567-e89b-42d3-a456-426614174000');
+    expect(nativeRandomUUID).toHaveBeenCalledOnce();
+  });
+
+  it('generates an RFC 4122 version 4 UUID when the native implementation is unavailable', () => {
+    setWindowProperty('crypto', undefined);
+    vi.spyOn(Math, 'random').mockReturnValue(0.1);
+
+    expect(randomUUID()).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+
+  it('uses Web Crypto random values before legacy fallbacks', () => {
+    const webCryptoGetRandomValues = vi.fn((result: Uint8Array) => {
+      result[0] = 231;
+      return result;
+    });
+    const msCryptoGetRandomValues = vi.fn();
+    const mathRandom = vi.spyOn(Math, 'random');
+    setWindowProperty('crypto', { getRandomValues: webCryptoGetRandomValues });
+    setWindowProperty('msCrypto', { getRandomValues: msCryptoGetRandomValues });
+
+    expect(getRandomValues()).toBe(231);
+    expect(webCryptoGetRandomValues).toHaveBeenCalledOnce();
+    expect(webCryptoGetRandomValues.mock.calls[0][0]).toBeInstanceOf(Uint8Array);
+    expect(webCryptoGetRandomValues.mock.calls[0][0]).toHaveLength(1);
+    expect(msCryptoGetRandomValues).not.toHaveBeenCalled();
+    expect(mathRandom).not.toHaveBeenCalled();
+  });
+
+  it('uses msCrypto when Web Crypto is unavailable', () => {
+    const msCryptoGetRandomValues = vi.fn((result: Uint8Array) => {
+      result[0] = 91;
+      return result;
+    });
+    const mathRandom = vi.spyOn(Math, 'random');
+    setWindowProperty('crypto', undefined);
+    setWindowProperty('msCrypto', { getRandomValues: msCryptoGetRandomValues });
+
+    expect(getRandomValues()).toBe(91);
+    expect(msCryptoGetRandomValues).toHaveBeenCalledOnce();
+    expect(mathRandom).not.toHaveBeenCalled();
+  });
+
+  it('uses Math.random as the final byte fallback', () => {
+    setWindowProperty('crypto', undefined);
+    setWindowProperty('msCrypto', undefined);
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+
+    expect(getRandomValues()).toBe(128);
+  });
+});

--- a/projects/ngclient/src/app/core/services/password-generator.service.spec.ts
+++ b/projects/ngclient/src/app/core/services/password-generator.service.spec.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PasswordGeneratorService } from './password-generator.service';
+
+const originalCryptoDescriptor = Object.getOwnPropertyDescriptor(window, 'crypto');
+
+describe('PasswordGeneratorService', () => {
+  let service: PasswordGeneratorService;
+  let getRandomValuesMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    getRandomValuesMock = vi.fn((result: Uint8Array) => result);
+    Object.defineProperty(window, 'crypto', {
+      configurable: true,
+      value: { getRandomValues: getRandomValuesMock },
+    });
+    service = new PasswordGeneratorService();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalCryptoDescriptor) {
+      Object.defineProperty(window, 'crypto', originalCryptoDescriptor);
+    } else {
+      delete (window as unknown as Record<string, unknown>)['crypto'];
+    }
+  });
+
+  const returnByte = (value: number) =>
+    getRandomValuesMock.mockImplementationOnce((result: Uint8Array) => {
+      result[0] = value;
+      return result;
+    });
+
+  it.each([
+    ['', 1],
+    ['abcdefgh', 2],
+    ['abcdEFGH', 3],
+    ['abcdEF12', 4],
+    ['abcdEF1!', 5],
+    ['VeryLongPassword123!WithMoreCharacters', 5],
+  ])('assigns strength %s to %s', (password, expectedStrength) => {
+    expect(service.calculatePasswordStrength(password)).toBe(expectedStrength);
+  });
+
+  it('generates the requested length using the default pattern', () => {
+    returnByte('A'.charCodeAt(0));
+    returnByte('z'.charCodeAt(0));
+    returnByte('0'.charCodeAt(0));
+    returnByte('!'.charCodeAt(0));
+
+    expect(service.generatePassword(4)).toBe('Az0!');
+    expect(getRandomValuesMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('rejects characters outside a custom pattern', () => {
+    returnByte('C'.charCodeAt(0));
+    returnByte('A'.charCodeAt(0));
+    returnByte('D'.charCodeAt(0));
+    returnByte('B'.charCodeAt(0));
+
+    expect(service.generatePassword(2, /[AB]/)).toBe('AB');
+    expect(getRandomValuesMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('retries until a strong password is generated', () => {
+    const generatePassword = vi
+      .spyOn(service, 'generatePassword')
+      .mockReturnValueOnce('abcdefgh')
+      .mockReturnValueOnce('Abcdef1!');
+
+    expect(service.generate(8)).toBe('Abcdef1!');
+    expect(generatePassword).toHaveBeenCalledTimes(2);
+    expect(generatePassword).toHaveBeenNthCalledWith(1, 8, expect.any(RegExp));
+    expect(generatePassword).toHaveBeenNthCalledWith(2, 8, expect.any(RegExp));
+  });
+});


### PR DESCRIPTION
## Summary

- add deterministic unit tests for password strength, generation, and retry behavior
- cover native and fallback UUID generation paths
- cover Web Crypto, legacy `msCrypto`, and `Math.random` byte generation paths

This is a test-only change. Production code, dependencies, public APIs, and lockfiles are unchanged.

## Tests

- password strength contributions from length, mixed case, digits, and symbols
- default and custom character patterns, including rejected random bytes
- retrying weak generated passwords until the required strength is reached
- native `randomUUID()` delegation and RFC 4122 version 4 fallback format
- random-byte fallback priority: Web Crypto, `msCrypto`, then `Math.random`

All browser crypto properties, random functions, and spies are restored after each test so the suite remains deterministic and order-independent.

## Validation

- `bun install --frozen-lockfile`
- Prettier check for both added specs
- focused suites: 2 files, 14 tests passed
- full Vitest suite: 26 files, 258 tests passed
- `bun run gen:font`
- `bun run ng -- build ngclient --configuration production`

Part of #273
