### PR TITLE
Add production build CI

### DIFF
--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -1,0 +1,31 @@
+name: Production Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  production-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Generate font assets
+        run: bun run gen:font
+
+      - name: Build production application
+        run: bun run ng -- build ngclient --configuration production


### PR DESCRIPTION
## Summary

- add a dedicated Production Build workflow for pull requests and pushes to `main`
- install dependencies from the Bun lockfile before generating font assets
- build the Angular application with the production configuration independently from Unit Tests

This keeps the existing Unit Tests workflow and its check name unchanged while ensuring production-only compilation, optimization, and asset generation failures are caught before merge.

## Validation

- `bun install --frozen-lockfile`
- `bun run gen:font`
- `bun run ng -- build ngclient --configuration production`
- `bun run test:ci` (28 files, 278 tests)
- `bun x prettier --check .github/workflows/production-build.yml`

Part of #273