### PR TITLE
Fix custom form validator behavior

### DIFF
--- a/projects/ngclient/src/app/core/validators/custom.validators.spec.ts
+++ b/projects/ngclient/src/app/core/validators/custom.validators.spec.ts
@@ -1,0 +1,170 @@
+import { FormBuilder, FormControl, Validators } from '@angular/forms';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { validateIf, validateWhen, watchField } from './custom.validators';
+
+const fb = new FormBuilder();
+
+describe('custom validators', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('validateWhen', () => {
+    it('skips validation when the control has no parent', () => {
+      const validator = validateWhen(() => true, Validators.required);
+
+      expect(validator(new FormControl(''))).toBeNull();
+    });
+
+    it('skips validation when the predicate is false', () => {
+      const form = fb.group({
+        enabled: fb.control(false),
+        value: fb.control('', [validateWhen((parent) => parent.value.enabled, Validators.required)]),
+      });
+      form.controls.value.updateValueAndValidity();
+
+      expect(form.controls.value.valid).toBe(true);
+      expect(form.controls.value.errors).toBeNull();
+    });
+
+    it('returns the first validation error in the default namespace', () => {
+      const firstValidator = vi.fn(() => ({ first: true }));
+      const secondValidator = vi.fn(() => ({ second: true }));
+      const form = fb.group({
+        enabled: fb.control(true),
+        value: fb.control('', [validateWhen((parent) => parent.value.enabled, [firstValidator, secondValidator])]),
+      });
+      form.controls.value.updateValueAndValidity();
+
+      expect(form.controls.value.errors).toEqual({ conditional: { first: true } });
+      expect(firstValidator).toHaveBeenCalled();
+      expect(secondValidator).not.toHaveBeenCalled();
+    });
+
+    it('returns the validation error directly when the namespace is empty', () => {
+      const form = fb.group({
+        enabled: fb.control(true),
+        value: fb.control('', [validateWhen((parent) => parent.value.enabled, Validators.required, '')]),
+      });
+      form.controls.value.updateValueAndValidity();
+
+      expect(form.controls.value.errors).toEqual({ required: true });
+    });
+
+    it('returns no error when every validator succeeds', () => {
+      const form = fb.group({
+        enabled: fb.control(true),
+        value: fb.control('value', [
+          validateWhen((parent) => parent.value.enabled, [Validators.required, Validators.minLength(3)]),
+        ]),
+      });
+      form.controls.value.updateValueAndValidity();
+
+      expect(form.controls.value.valid).toBe(true);
+      expect(form.controls.value.errors).toBeNull();
+    });
+  });
+
+  describe('validateIf', () => {
+    it('skips validation when the control has no parent', () => {
+      const validator = validateIf('enabled', true, Validators.required);
+
+      expect(validator(new FormControl(''))).toBeNull();
+    });
+
+    it('returns the first validation error when a scalar condition matches', () => {
+      const firstValidator = vi.fn(() => ({ first: true }));
+      const secondValidator = vi.fn(() => ({ second: true }));
+      const form = fb.group({
+        enabled: fb.control(true),
+        value: fb.control('', [validateIf('enabled', true, [firstValidator, secondValidator])]),
+      });
+      form.controls.value.updateValueAndValidity();
+
+      expect(form.controls.value.errors).toEqual({ first: true });
+      expect(firstValidator).toHaveBeenCalled();
+      expect(secondValidator).not.toHaveBeenCalled();
+    });
+
+    it('validates when the current value is in the allowed values', () => {
+      const form = fb.group({
+        mode: fb.control('second'),
+        value: fb.control('', [validateIf('mode', ['first', 'second'], Validators.required)]),
+      });
+      form.controls.value.updateValueAndValidity();
+
+      expect(form.controls.value.errors).toEqual({ required: true });
+    });
+
+    it('returns no error when the condition does not match', () => {
+      const form = fb.group({
+        enabled: fb.control(false),
+        value: fb.control('', [validateIf('enabled', true, Validators.required)]),
+      });
+      form.controls.value.updateValueAndValidity();
+
+      expect(form.controls.value.valid).toBe(true);
+      expect(form.controls.value.errors).toBeNull();
+    });
+
+    it('returns no error and warns when the conditional field is missing', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const form = fb.group({
+        value: fb.control('', [validateIf('missing', true, Validators.required)]),
+      });
+      form.controls.value.updateValueAndValidity();
+
+      expect(form.controls.value.valid).toBe(true);
+      expect(form.controls.value.errors).toBeNull();
+      expect(warn).toHaveBeenCalledWith('Conditional field not found');
+    });
+
+    it('returns no error when the condition matches and validation succeeds', () => {
+      const form = fb.group({
+        enabled: fb.control(true),
+        value: fb.control('value', [validateIf('enabled', true, Validators.required)]),
+      });
+      form.controls.value.updateValueAndValidity();
+
+      expect(form.controls.value.valid).toBe(true);
+      expect(form.controls.value.errors).toBeNull();
+    });
+  });
+
+  describe('watchField', () => {
+    it('revalidates General-style password fields when encryption changes', async () => {
+      const form = fb.group({
+        encryption: fb.control('aes', [watchField()]),
+        password: fb.control('', [validateWhen((parent) => parent.value.encryption !== '-', Validators.required)]),
+      });
+      form.controls.password.updateValueAndValidity();
+      const revalidatePassword = vi.spyOn(form.controls.password, 'updateValueAndValidity');
+
+      expect(form.controls.password.invalid).toBe(true);
+
+      form.controls.encryption.setValue('-');
+      await Promise.resolve();
+
+      expect(revalidatePassword).toHaveBeenCalled();
+      expect(form.controls.password.valid).toBe(true);
+    });
+
+    it('revalidates Export-style password fields when encryption is enabled', async () => {
+      const form = fb.group({
+        encryption: fb.control(false, [watchField()]),
+        password: fb.control('', [validateIf('encryption', true, Validators.required)]),
+      });
+
+      expect(form.controls.password.valid).toBe(true);
+
+      form.controls.encryption.setValue(true);
+      await Promise.resolve();
+
+      expect(form.controls.password.errors).toEqual({ required: true });
+
+      form.controls.password.setValue('secret');
+
+      expect(form.controls.password.valid).toBe(true);
+    });
+  });
+});

--- a/projects/ngclient/src/app/core/validators/custom.validators.ts
+++ b/projects/ngclient/src/app/core/validators/custom.validators.ts
@@ -15,7 +15,14 @@ export function validateWhen(
     if (predicate(control.parent)) {
       const validatorArr = Array.isArray(validators) ? validators : [validators];
 
-      error = validatorArr.find((validator) => validator(control) !== null) ?? null;
+      for (const validator of validatorArr) {
+        const validationResult = validator(control);
+
+        if (validationResult !== null) {
+          error = validationResult;
+          break;
+        }
+      }
     }
 
     if (errorNamespace && error) {
@@ -30,14 +37,18 @@ export function validateWhen(
 
 export function watchField() {
   return (control: AbstractControl): null => {
-    if (!control.parent) {
+    const parent = control.parent;
+
+    if (!parent) {
       return null;
     }
 
-    Object.values(control.parent.controls).forEach((ctrl) => {
-      if (ctrl !== control) {
-        ctrl.updateValueAndValidity();
-      }
+    queueMicrotask(() => {
+      Object.values(parent.controls).forEach((ctrl) => {
+        if (ctrl !== control) {
+          ctrl.updateValueAndValidity();
+        }
+      });
     });
 
     return null;
@@ -55,7 +66,7 @@ export function validateIf<T>(
       return null;
     }
 
-    let error: ValidationErrors = {};
+    let error: ValidationErrors | null = null;
 
     const conditionalFormCtrl = control.parent.get(conditionalFieldName);
 
@@ -68,16 +79,15 @@ export function validateIf<T>(
 
     if (
       isConditionalValueArray
-        ? conditionalFormCtrl.value?.includes(conditionalValue)
+        ? conditionalValue.includes(conditionalFormCtrl.value)
         : conditionalFormCtrl.value === conditionalValue
     ) {
       const validatorArr = Array.isArray(validators) ? validators : [validators];
       for (const validator of validatorArr) {
         const validationResult = validator(control);
-        const _currentErrors = error ? error : {};
 
         if (validationResult !== null) {
-          error = { ..._currentErrors, ...validationResult };
+          error = validationResult;
           break;
         }
       }


### PR DESCRIPTION
## Summary

- return actual validation errors from `validateWhen` instead of the matching validator function
- fix `validateIf` allowed-value matching and return `null` when conditional validation does not produce an error
- revalidate dependent fields after Angular has updated the parent form value
- add focused tests for the validators and the General/Export conditional password flows

The deferred sibling revalidation keeps the existing `watchField` intent while preventing `validateWhen` predicates from reading the previous parent value during the controlling field update.

## Validation

- `bun install --frozen-lockfile`
- `bun run ng -- test ngclient --watch=false --include projects/ngclient/src/app/core/validators/custom.validators.spec.ts` (13 tests)
- `bun run test:ci` (29 files, 291 tests)
- `bun run gen:font`
- `bun run ng -- build ngclient --configuration production`
- `bun x prettier --check projects/ngclient/src/app/core/validators/custom.validators.ts projects/ngclient/src/app/core/validators/custom.validators.spec.ts`

Part of #273