### PR TITLE
Update GitHub Actions versions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1 # shallow clone
 
@@ -26,7 +26,7 @@ jobs:
         run: git fetch --unshallow
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary

- update `actions/checkout` to the latest v7 major in all workflows
- update `actions/setup-node` to the latest v7 major in the npm publish workflow
- keep `oven-sh/setup-bun@v2`, which is already the latest major

This preserves the existing workflow triggers, package-change detection, build commands, and publish behavior.

## Validation

- verified the latest stable releases from the official Action repositories
- `prettier --check .github/workflows/unit-tests.yml .github/workflows/production-build.yml .github/workflows/npm-publish.yml`
- verified all workflow Action references use the expected current major tags

The pull request Unit Tests and Production Build workflows also exercise `actions/checkout@v7` directly.