### PR TITLE
Harden HTTP interceptor request handling

### DIFF
--- a/projects/ngclient/src/app/core/interceptors/http.interceptor.spec.ts
+++ b/projects/ngclient/src/app/core/interceptors/http.interceptor.spec.ts
@@ -1,0 +1,233 @@
+import {
+  HttpErrorResponse,
+  HttpEvent,
+  HttpHandlerFn,
+  HttpHeaders,
+  HttpRequest,
+  HttpResponse,
+} from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { ShipAlertService } from '@ship-ui/core/ship-alert';
+import { firstValueFrom, Observable, of, throwError } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ENVIRONMENT_TOKEN } from '../../../environments/environment-token';
+import { client } from '../openapi/client.gen';
+import { LOCALSTORAGE } from '../services/localstorage.token';
+import { AppAuthState, dummytoken } from '../states/app-auth.state';
+import { httpInterceptor } from './http.interceptor';
+
+describe('httpInterceptor', () => {
+  const apiRoot = '/proxy/api';
+  let currentToken: string | null;
+  let auth: {
+    token: ReturnType<typeof vi.fn>;
+    refreshToken: ReturnType<typeof vi.fn>;
+    logout: ReturnType<typeof vi.fn>;
+  };
+  let router: { navigate: ReturnType<typeof vi.fn> };
+  let localStorage: { getItem: ReturnType<typeof vi.fn> };
+  let alerts: { error: ReturnType<typeof vi.fn> };
+
+  const runInterceptor = (request: HttpRequest<unknown>, next: HttpHandlerFn) =>
+    TestBed.runInInjectionContext(() => httpInterceptor(request, next));
+
+  const httpError = (status: number, message = 'request failed') =>
+    new HttpErrorResponse({
+      error: { Error: message },
+      status,
+      statusText: message,
+      url: `${apiRoot}/v1/test`,
+    });
+
+  beforeEach(() => {
+    currentToken = 'initial-token';
+    auth = {
+      token: vi.fn(() => currentToken),
+      refreshToken: vi.fn(() => {
+        currentToken = 'refreshed-token';
+        return of({ AccessToken: currentToken });
+      }),
+      logout: vi.fn(),
+    };
+    router = { navigate: vi.fn() };
+    localStorage = { getItem: vi.fn(() => 'ja-JP') };
+    alerts = { error: vi.fn() };
+
+    client.setConfig({ baseUrl: '/proxy' });
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AppAuthState, useValue: auth },
+        { provide: Router, useValue: router },
+        { provide: LOCALSTORAGE, useValue: localStorage },
+        { provide: ShipAlertService, useValue: alerts },
+        {
+          provide: ENVIRONMENT_TOKEN,
+          useValue: {
+            production: false,
+            baseUrl: '/api',
+            machineServerUrl: '',
+            defaultTimeout: 30_000,
+          },
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    client.setConfig({ baseUrl: '' });
+    TestBed.resetTestingModule();
+    vi.restoreAllMocks();
+  });
+
+  it('adds authentication and the mapped UI locale to API requests', async () => {
+    const request = new HttpRequest('GET', `${apiRoot}/v1/backups`);
+    const next = vi.fn((_request: HttpRequest<unknown>) => of(new HttpResponse({ status: 200 })));
+
+    await firstValueFrom(runInterceptor(request, next));
+
+    const forwarded = next.mock.calls[0][0];
+    expect(forwarded.headers.get('Authorization')).toBe('Bearer initial-token');
+    expect(forwarded.headers.get('X-Ui-Language')).toBe('ja');
+  });
+
+  it('does not add a UI locale header for en-US', async () => {
+    localStorage.getItem.mockReturnValue('en-US');
+    const request = new HttpRequest('GET', `${apiRoot}/v1/backups`);
+    const next = vi.fn((_request: HttpRequest<unknown>) => of(new HttpResponse({ status: 200 })));
+
+    await firstValueFrom(runInterceptor(request, next));
+
+    expect(next.mock.calls[0][0].headers.has('X-Ui-Language')).toBe(false);
+  });
+
+  it.each(['https://example.com/data', '/proxy/apiary/v1/data'])(
+    'does not add authentication to requests outside the Duplicati API: %s',
+    async (url) => {
+      const request = new HttpRequest('GET', url);
+      const next = vi.fn((_request: HttpRequest<unknown>) => of(new HttpResponse({ status: 200 })));
+
+      await firstValueFrom(runInterceptor(request, next));
+
+      expect(next.mock.calls[0][0].headers.has('Authorization')).toBe(false);
+    }
+  );
+
+  it('does not add authentication to proxy detection requests', async () => {
+    const request = new HttpRequest('GET', `${apiRoot}/v1/auth/status`, {
+      headers: new HttpHeaders({ 'custom-proxy-check': 'true' }),
+    });
+    const next = vi.fn((_request: HttpRequest<unknown>) => of(new HttpResponse({ status: 200 })));
+
+    await firstValueFrom(runInterceptor(request, next));
+
+    expect(next.mock.calls[0][0].headers.has('Authorization')).toBe(false);
+  });
+
+  it('does not add authentication when using the relay dummy token', async () => {
+    currentToken = dummytoken;
+    const request = new HttpRequest('GET', `${apiRoot}/v1/backups`);
+    const next = vi.fn((_request: HttpRequest<unknown>) => of(new HttpResponse({ status: 200 })));
+
+    await firstValueFrom(runInterceptor(request, next));
+
+    expect(next.mock.calls[0][0].headers.has('Authorization')).toBe(false);
+  });
+
+  it('refreshes an API request once and preserves its headers and locale', async () => {
+    const request = new HttpRequest('GET', `${apiRoot}/v1/backups`, {
+      headers: new HttpHeaders({ 'X-Custom': 'preserved' }),
+    });
+    const response = new HttpResponse({ status: 200, body: { ok: true } });
+    const next = vi
+      .fn<(request: HttpRequest<unknown>) => Observable<HttpEvent<unknown>>>()
+      .mockReturnValueOnce(throwError(() => httpError(401, 'unauthorized')))
+      .mockReturnValueOnce(of(response));
+
+    await expect(firstValueFrom(runInterceptor(request, next))).resolves.toBe(response);
+
+    expect(auth.refreshToken).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledTimes(2);
+    const retried = next.mock.calls[1][0];
+    expect(retried.headers.get('Authorization')).toBe('Bearer refreshed-token');
+    expect(retried.headers.get('X-Ui-Language')).toBe('ja');
+    expect(retried.headers.get('X-Custom')).toBe('preserved');
+    expect(alerts.error).not.toHaveBeenCalled();
+  });
+
+  it('does not refresh or attach credentials after an external request returns 401', async () => {
+    const request = new HttpRequest('GET', 'https://example.com/private');
+    const next = vi.fn((_request: HttpRequest<unknown>) => throwError(() => httpError(401, 'unauthorized')));
+
+    await expect(firstValueFrom(runInterceptor(request, next))).rejects.toMatchObject({
+      message: 'unauthorized',
+    });
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(next.mock.calls[0][0].headers.has('Authorization')).toBe(false);
+    expect(auth.refreshToken).not.toHaveBeenCalled();
+    expect(alerts.error).toHaveBeenCalledWith('unauthorized');
+  });
+
+  it.each(['login', 'logout'])('does not refresh failed auth %s requests', async (operation) => {
+    const request = new HttpRequest('POST', `${apiRoot}/v1/auth/${operation}`, null);
+    const next = vi.fn((_request: HttpRequest<unknown>) => throwError(() => httpError(401, 'unauthorized')));
+
+    await expect(firstValueFrom(runInterceptor(request, next))).rejects.toBeDefined();
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(auth.refreshToken).not.toHaveBeenCalled();
+  });
+
+  it('logs out when the refresh endpoint returns 401', async () => {
+    const request = new HttpRequest('POST', `${apiRoot}/v1/auth/refresh`, null);
+    const next = vi.fn((_request: HttpRequest<unknown>) => throwError(() => httpError(401, 'unauthorized')));
+
+    await expect(firstValueFrom(runInterceptor(request, next))).rejects.toBeDefined();
+
+    expect(auth.logout).toHaveBeenCalledOnce();
+    expect(router.navigate).toHaveBeenCalledWith(['/logout']);
+    expect(auth.refreshToken).not.toHaveBeenCalled();
+    expect(alerts.error).not.toHaveBeenCalled();
+  });
+
+  it('turns unsuccessful API v2 responses into notified errors', async () => {
+    const request = new HttpRequest('POST', `${apiRoot}/v2/command`, null);
+    const response = new HttpResponse({
+      status: 200,
+      body: { Success: false, Error: 'command failed' },
+    });
+    const next = vi.fn((_request: HttpRequest<unknown>) => of(response));
+
+    await expect(firstValueFrom(runInterceptor(request, next))).rejects.toMatchObject({
+      message: 'command failed',
+      error: {
+        requestBody: { Success: false, Error: 'command failed' },
+      },
+    });
+    expect(alerts.error).toHaveBeenCalledWith('command failed');
+  });
+
+  it('notifies the user about regular API errors', async () => {
+    const request = new HttpRequest('GET', `${apiRoot}/v1/backups`);
+    const next = vi.fn((_request: HttpRequest<unknown>) => throwError(() => httpError(500, 'server failed')));
+
+    await expect(firstValueFrom(runInterceptor(request, next))).rejects.toMatchObject({
+      message: 'server failed',
+    });
+    expect(alerts.error).toHaveBeenCalledWith('server failed');
+  });
+
+  it.each([
+    [`${apiRoot}/v1/progressstate`, 404],
+    [`${apiRoot}/v1/remoteoperation/test`, 500],
+    [`${apiRoot}/v1/filesystem/validate`, 500],
+  ])('suppresses notifications for expected errors from %s', async (url, status) => {
+    const request = new HttpRequest('GET', url);
+    const next = vi.fn((_request: HttpRequest<unknown>) => throwError(() => httpError(status, 'expected error')));
+
+    await expect(firstValueFrom(runInterceptor(request, next))).rejects.toBeDefined();
+
+    expect(alerts.error).not.toHaveBeenCalled();
+  });
+});

--- a/projects/ngclient/src/app/core/interceptors/http.interceptor.ts
+++ b/projects/ngclient/src/app/core/interceptors/http.interceptor.ts
@@ -18,6 +18,8 @@ export const httpInterceptor: HttpInterceptorFn = (req, next) => {
   const shipAlertService = inject(ShipAlertService);
   const mappedLocale = mapLocale(locale);
   const prefix = getApiBase();
+  const apiBaseUrl = prefix + env.baseUrl;
+  const isApiRequest = req.url === apiBaseUrl || req.url.startsWith(`${apiBaseUrl}/`);
   const isLoginRequest = req.url === `${prefix}/api/v1/auth/login`;
   const isLogoutRequest = req.url === `${prefix}/api/v1/auth/logout`;
   const isRefreshRequest = req.url === `${prefix}/api/v1/auth/refresh`;
@@ -32,7 +34,7 @@ export const httpInterceptor: HttpInterceptorFn = (req, next) => {
   const hasCustomProxyHeader = req.headers.has('custom-proxy-check');
   const IS_PROXY_DETECT_REQUEST = hasCustomProxyHeader || token === dummytoken;
 
-  if (token && req.url.startsWith(prefix + env.baseUrl) && !IS_PROXY_DETECT_REQUEST) {
+  if (token && isApiRequest && !IS_PROXY_DETECT_REQUEST) {
     let newHeaders = req.headers.set('Authorization', `Bearer ${token}`);
 
     if (locale && locale !== 'en-US') {
@@ -86,14 +88,14 @@ export const httpInterceptor: HttpInterceptorFn = (req, next) => {
         }
 
         if (!isLoginRequest && !isRefreshRequest && !isLogoutRequest) {
-          if (error.status === 401) {
+          if (isApiRequest && error.status === 401) {
             notifyUser = false;
 
             return auth.refreshToken().pipe(
               switchMap(() => {
                 return next(
-                  req.clone({
-                    headers: req.headers.set('Authorization', `Bearer ${auth.token()}`),
+                  modifiedRequest.clone({
+                    headers: modifiedRequest.headers.set('Authorization', `Bearer ${auth.token()}`),
                   })
                 );
               })

--- a/projects/ngclient/src/app/core/interceptors/http.interceptor.ts
+++ b/projects/ngclient/src/app/core/interceptors/http.interceptor.ts
@@ -20,13 +20,13 @@ export const httpInterceptor: HttpInterceptorFn = (req, next) => {
   const prefix = getApiBase();
   const apiBaseUrl = prefix + env.baseUrl;
   const isApiRequest = req.url === apiBaseUrl || req.url.startsWith(`${apiBaseUrl}/`);
-  const isLoginRequest = req.url === `${prefix}/api/v1/auth/login`;
-  const isLogoutRequest = req.url === `${prefix}/api/v1/auth/logout`;
-  const isRefreshRequest = req.url === `${prefix}/api/v1/auth/refresh`;
-  const isProgressStateRequest = req.url === `${prefix}/api/v1/progressstate`;
-  const isConnectionTestRequest = req.url === `${prefix}/api/v1/remoteoperation/test`;
-  const isValidateFsTestRequest = req.url === `${prefix}/api/v1/filesystem/validate`;
-  const isV2Request = req.url.startsWith(`${prefix}/api/v2/`);
+  const isLoginRequest = req.url === `${apiBaseUrl}/v1/auth/login`;
+  const isLogoutRequest = req.url === `${apiBaseUrl}/v1/auth/logout`;
+  const isRefreshRequest = req.url === `${apiBaseUrl}/v1/auth/refresh`;
+  const isProgressStateRequest = req.url === `${apiBaseUrl}/v1/progressstate`;
+  const isConnectionTestRequest = req.url === `${apiBaseUrl}/v1/remoteoperation/test`;
+  const isValidateFsTestRequest = req.url === `${apiBaseUrl}/v1/filesystem/validate`;
+  const isV2Request = req.url.startsWith(`${apiBaseUrl}/v2/`);
   const token = auth.token();
 
   let modifiedRequest = req;


### PR DESCRIPTION
## Summary

- scope authentication and token refresh handling to Duplicati API requests
- preserve locale and existing request headers when retrying after a successful token refresh
- add deterministic Angular TestBed and Vitest coverage for authentication, retries, API v2 errors, and notification behavior

## Root cause

The interceptor limited initial Bearer token attachment to API URLs, but its 401 recovery path was not similarly scoped. A 401 from an unrelated URL could therefore trigger a Duplicati token refresh and retry that external request with the refreshed Bearer token.

The retry also cloned the original request rather than the interceptor-modified request, which discarded the `X-Ui-Language` header added before the first attempt.

## Changes

- identify API requests with an exact or slash-delimited API base match
- refresh and retry only failed Duplicati API requests
- retry from the modified request while replacing its Authorization header with the refreshed token
- retain the existing login, logout, refresh, proxy detection, relay dummy token, expected-error suppression, and API v2 error behavior
- leave generated OpenAPI code and API contracts unchanged

## Validation

- `bun install --frozen-lockfile`
- `bunx prettier --check projects/ngclient/src/app/core/interceptors/http.interceptor.ts projects/ngclient/src/app/core/interceptors/http.interceptor.spec.ts`
- targeted interceptor suite: 16 tests passed
- `bun run test:ci`: 29 files and 294 tests passed
- `bun run gen:font`
- `bun run ng -- build ngclient --configuration production`

Part of #273