### PR TITLE
fix: prevent double slash in destination paths

### DIFF
--- a/projects/ngclient/src/app/backup/destination/destination.config-utilities.spec.ts
+++ b/projects/ngclient/src/app/backup/destination/destination.config-utilities.spec.ts
@@ -109,6 +109,10 @@ describe('destination URL utilities', () => {
       expect(concatPaths(...paths)).toBe(expected);
     });
 
+    it('does not create a double slash when a path starts with a slash', () => {
+      expect(concatPaths('server:443', '/Sicherung/nuc/config')).toBe('server:443/Sicherung/nuc/config');
+    });
+
     it('encodes path segments without encoding slashes', () => {
       expect(encodePathPreservingSlashes('folder name/file#1/日本語')).toBe(
         'folder%20name/file%231/%E6%97%A5%E6%9C%AC%E8%AA%9E'

--- a/projects/ngclient/src/app/backup/destination/destination.config-utilities.ts
+++ b/projects/ngclient/src/app/backup/destination/destination.config-utilities.ts
@@ -162,7 +162,7 @@ export function concatPaths(...paths: (string | null | undefined)[]) {
   let result = '';
   for (const path of paths) {
     if (path === null || path === undefined || path === '') continue;
-    result += result.endsWith('/') || result == '' ? path : '/' + path;
+    result += result.endsWith('/') || result == '' || path.startsWith('/') ? path : '/' + path;
   }
   return result;
 }


### PR DESCRIPTION
## Summary

Fixes an issue where destination paths starting with `/` could produce an unintended double slash when concatenated with the server/path prefix.

For example:

`server:443` + `/Sicherung/nuc/config`

previously resulted in:

`server:443//Sicherung/nuc/config`

and now correctly produces:

`server:443/Sicherung/nuc/config`

## Changes

- Prevent `concatPaths()` from introducing a duplicate `/` when the next path segment already starts with `/`.
- Added a regression test covering this case.

## Validation

- Targeted test suite: **38/38 tests passed**
- `git diff --check`: passed
