### PR TITLE
Propagate folder exclusions through the file tree

### DIFF
--- a/projects/ngclient/src/app/core/components/file-tree/file-tree.component.spec.ts
+++ b/projects/ngclient/src/app/core/components/file-tree/file-tree.component.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { getInheritedExclusionState, TreeEvalEnum } from './file-tree.component';
+
+describe('file tree exclusion inheritance', () => {
+  it('marks the direct child of an excluded folder as excluded by its parent', () => {
+    expect(getInheritedExclusionState(TreeEvalEnum.Excluded)).toBe(TreeEvalEnum.ExcludedByParent);
+  });
+
+  it('propagates an excluded folder state through deeper descendants', () => {
+    const childState = getInheritedExclusionState(TreeEvalEnum.Excluded);
+    const grandchildState = getInheritedExclusionState(childState);
+    const greatGrandchildState = getInheritedExclusionState(grandchildState);
+
+    expect(childState).toBe(TreeEvalEnum.ExcludedByParent);
+    expect(grandchildState).toBe(TreeEvalEnum.ExcludedByParent);
+    expect(greatGrandchildState).toBe(TreeEvalEnum.ExcludedByParent);
+  });
+
+  it.each([TreeEvalEnum.None, TreeEvalEnum.Included, null, undefined])(
+    'does not inherit an exclusion from parent state %s',
+    (parentState) => {
+      expect(getInheritedExclusionState(parentState)).toBeNull();
+    }
+  );
+});

--- a/projects/ngclient/src/app/core/components/file-tree/file-tree.component.ts
+++ b/projects/ngclient/src/app/core/components/file-tree/file-tree.component.ts
@@ -38,13 +38,23 @@ import { SysinfoState } from '../../states/sysinfo.state';
 import { ConfirmDialogComponent } from '../confirm-dialog/confirm-dialog.component';
 import { globMatchesPath, regexMatchesPath } from './file-tree-filter-matcher';
 
-enum TreeEvalEnum {
+export enum TreeEvalEnum {
   ExcludedByParent = -2,
   Excluded = -1,
   None = 0,
   Included = 1,
   IncludedByParent = 2,
 }
+
+export const getInheritedExclusionState = (
+  parentState: TreeEvalEnum | null | undefined
+): TreeEvalEnum.ExcludedByParent | null => {
+  if (parentState === TreeEvalEnum.Excluded || parentState === TreeEvalEnum.ExcludedByParent) {
+    return TreeEvalEnum.ExcludedByParent;
+  }
+
+  return null;
+};
 
 type TreeNode = TreeNodeDto & {
   accepted?: boolean;
@@ -764,7 +774,8 @@ export default class FileTreeComponent {
     currentPaths: string[],
     nodeType: string
   ): TreeEvalEnum {
-    if (parentNode && parentNode.evalState === TreeEvalEnum.Excluded) return TreeEvalEnum.ExcludedByParent;
+    const inheritedExclusion = getInheritedExclusionState(parentNode?.evalState);
+    if (inheritedExclusion !== null) return inheritedExclusion;
 
     const evalMap = this.#remoteFilterResource.value();
     if (evalMap && evalMap.has(nodeId)) {
@@ -781,7 +792,8 @@ export default class FileTreeComponent {
     nodeType: string,
     parentNode: FileTreeNode | null | undefined
   ): TreeEvalEnum {
-    if (parentNode && parentNode.evalState === TreeEvalEnum.Excluded) return TreeEvalEnum.ExcludedByParent;
+    const inheritedExclusion = getInheritedExclusionState(parentNode?.evalState);
+    if (inheritedExclusion !== null) return inheritedExclusion;
 
     let result = TreeEvalEnum.None;
 


### PR DESCRIPTION
## Symptom

Excluding a folder in the source file tree only propagated the excluded display state to its immediate child. Deeper descendants could return to the included state instead of remaining excluded.

## Root cause

Both the local and remote evaluation paths used this condition:

```ts
if (parentNode && parentNode.evalState === TreeEvalEnum.Excluded)
  return TreeEvalEnum.ExcludedByParent;
```

The direct child of an excluded folder receives `ExcludedByParent`, not `Excluded`. The next descendant therefore failed this condition and was evaluated independently.

## Change

- add a shared pure helper that treats both `Excluded` and `ExcludedByParent` as inherited exclusions
- use the helper in both the local and remote evaluation paths
- keep all subsequent source and filter evaluation unchanged

A recursive ancestor walk is not needed for the normal tree. `searchableTreeNodes()` preserves insertion order, lazy browsing appends children only after their parent has been loaded, and initial path loading builds parent-to-child URL pieces whose order is preserved by `forkJoin` and `flatMap`. The later `filter()` also preserves that order, so the parent is already present in `nodeMap` when a visible child is evaluated.

## Red to green

The regression test was first run with the existing `Excluded`-only condition moved into the helper without changing its behavior:

- 1 file failed
- 1 test failed and 5 passed
- the direct child passed, while the grandchild failed with `expected -2` and `received null`

After accepting `ExcludedByParent` as an inherited exclusion:

- targeted file tree suite: 6 tests passed
- full suite: 29 files and 284 tests passed, including all 278 pre-existing tests
- production Angular build passed
- `bun install --frozen-lockfile` completed with no changes
- the new spec passes Prettier check; a whole-file check of the existing component still reports unrelated pre-existing formatting differences, which are intentionally not included here

## User-visible side effect

The existing click guard ignores nodes whose state is `ExcludedByParent`. With this fix, deeper descendants are now also non-clickable, matching the behavior already used for the first inherited level.

## Not measured and out of scope

- I did not reproduce the flow manually in the GUI; visual behavior is based on the reporter video and the regression unit test.
- Search-result tree evaluation still passes no parent node and is unchanged.
- The separately reported loss of `--exclude-files-attributes` while editing is not addressed by this PR.
- The unused `IncludedByParent` enum member is unchanged.

Fixes duplicati/duplicati#7242