### PR TITLE
Preserve file attribute exclusions when editing

### DIFF
--- a/projects/ngclient/src/app/backup/backup.state.spec.ts
+++ b/projects/ngclient/src/app/backup/backup.state.spec.ts
@@ -68,4 +68,26 @@ describe('BackupState destination identity', () => {
       urlKey: 'secondary',
     });
   });
+
+  it('preserves file attribute exclusions when options are loaded and saved', () => {
+    state.mapOptionsToForms({
+      Settings: [{ Name: '--exclude-files-attributes', Value: 'hidden' }],
+    } as BackupDto);
+
+    expect(state.mapFormsToSettings()).toContainEqual({
+      Name: '--exclude-files-attributes',
+      Value: 'hidden',
+    });
+  });
+
+  it('continues to round-trip the managed keep-versions option', () => {
+    state.mapOptionsToForms({
+      Settings: [{ Name: 'keep-versions', Value: '5' }],
+    } as BackupDto);
+
+    expect(state.mapFormsToSettings()).toContainEqual({
+      Name: 'keep-versions',
+      Value: '5',
+    });
+  });
 });

--- a/projects/ngclient/src/app/backup/backup.state.ts
+++ b/projects/ngclient/src/app/backup/backup.state.ts
@@ -557,7 +557,6 @@ export class BackupState {
     const legacyOptionValues = ['dblock-size', 'compression-module'];
     const modulesToIgnore = [
       '--no-encryption',
-      '--exclude-files-attributes',
       '--skip-files-larger-than',
       'encryption-module',
       'passphrase',


### PR DESCRIPTION
## Symptom

Opening and saving an existing backup in the new UI silently removes `--exclude-files-attributes`. This can cause hidden or system files that were previously excluded to enter later backups.

## Root cause

`mapOptionsToForms()` does not exclude `--exclude-files-attributes`, so the loaded setting remains in the generic `settings()` collection. However, `mapFormsToSettings()` listed it in `modulesToIgnore`, which removed it before serialization.

Every other ignored option has a separate output path:

- encryption options are rebuilt from the encryption form
- `dblock-size` and `compression-module` are rebuilt as legacy options
- retention options are rebuilt from the retention fields
- `--skip-files-larger-than` is added by the enclosing backup mapping flow

`--exclude-files-attributes` has no form field or replacement output path, so it was subtracted and never restored.

## Change

Remove `--exclude-files-attributes` from `modulesToIgnore`. The existing generic settings path now preserves its original name and value during load and save. No new UI, API, or storage format is introduced.

This PR is independent of #519, which fixes the first file-tree display report in the same upstream issue.

## Red to green

Before the production change, the round-trip regression test produced:

- 1 failed and 3 passed tests in `backup.state.spec.ts`
- the existing destination identity tests and the `keep-versions` control case passed
- the attribute exclusion assertion failed because the saved settings contained only `--no-encryption`

After removing the single ignore-list entry:

- targeted BackupState suite: 4 tests passed
- full suite: 28 files and 280 tests passed, including all 278 pre-existing tests
- `bun install --frozen-lockfile` completed with no changes
- Prettier check passed for both changed files
- production Angular build passed

## Not measured and out of scope

- I did not reproduce the edit flow manually in the GUI; the user-visible symptom is based on the reporter observation and the load-to-save unit regression test.
- No file-attribute selection UI is added.
- The separately maintained load and save exclusion lists are not refactored in this PR.
- The deep file-tree exclusion issue is handled separately by #519.
- No Duplicati server or legacy UI code is changed.

Addresses the second report in duplicati/duplicati#7242