### PR TITLE
Fix commandline result polling

### DIFF
--- a/projects/ngclient/src/app/backup/commandline-result/commandline-result.component.spec.ts
+++ b/projects/ngclient/src/app/backup/commandline-result/commandline-result.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
-import { BehaviorSubject, config, of, throwError } from 'rxjs';
+import { BehaviorSubject, of, throwError } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CommandLineLogOutputDto, DuplicatiServer } from '../../core/openapi';
 import CommandlineResultComponent from './commandline-result.component';
@@ -21,12 +21,9 @@ describe('CommandlineResultComponent', () => {
   let logOutput: HTMLElement;
   let getCommandline: ReturnType<typeof vi.fn>;
   let abortCommandline: ReturnType<typeof vi.fn>;
-  let previousUnhandledError: typeof config.onUnhandledError;
 
   beforeEach(() => {
     vi.useFakeTimers();
-    previousUnhandledError = config.onUnhandledError;
-    config.onUnhandledError = vi.fn();
     getCommandline = vi.fn(() => of(commandlineResponse()));
     abortCommandline = vi.fn(() => of({}));
 
@@ -71,7 +68,6 @@ describe('CommandlineResultComponent', () => {
 
   afterEach(() => {
     if (!fixture.componentRef.hostView.destroyed) fixture.destroy();
-    config.onUnhandledError = previousUnhandledError;
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
@@ -141,7 +137,7 @@ describe('CommandlineResultComponent', () => {
     expect(getCommandline).toHaveBeenCalledTimes(1);
   });
 
-  it('stops polling when aborting a missing command returns 404', async () => {
+  it('stops polling and marks the run finished when aborting a missing command returns 404', async () => {
     abortCommandline.mockReturnValue(throwError(() => ({ error: { status: 404 } })));
 
     component.abort();
@@ -149,7 +145,7 @@ describe('CommandlineResultComponent', () => {
 
     expect(abortCommandline).toHaveBeenCalledTimes(1);
     expect(getCommandline).not.toHaveBeenCalled();
-    expect(component.status()).toBe('starting');
+    expect(component.status()).toBe('finished');
   });
 
   it('stops polling when the component is destroyed', async () => {

--- a/projects/ngclient/src/app/backup/commandline-result/commandline-result.component.spec.ts
+++ b/projects/ngclient/src/app/backup/commandline-result/commandline-result.component.spec.ts
@@ -1,16 +1,35 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
-import { BehaviorSubject, of } from 'rxjs';
+import { BehaviorSubject, config, of, throwError } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { DuplicatiServer } from '../../core/openapi';
+import { CommandLineLogOutputDto, DuplicatiServer } from '../../core/openapi';
 import CommandlineResultComponent from './commandline-result.component';
+
+const commandlineResponse = (overrides: Partial<CommandLineLogOutputDto> = {}): CommandLineLogOutputDto => ({
+  Pagesize: 100,
+  Offset: 0,
+  Count: 0,
+  Items: [],
+  Started: true,
+  Finished: false,
+  ...overrides,
+});
 
 describe('CommandlineResultComponent', () => {
   let component: CommandlineResultComponent;
   let fixture: ComponentFixture<CommandlineResultComponent>;
   let logOutput: HTMLElement;
+  let getCommandline: ReturnType<typeof vi.fn>;
+  let abortCommandline: ReturnType<typeof vi.fn>;
+  let previousUnhandledError: typeof config.onUnhandledError;
 
   beforeEach(() => {
+    vi.useFakeTimers();
+    previousUnhandledError = config.onUnhandledError;
+    config.onUnhandledError = vi.fn();
+    getCommandline = vi.fn(() => of(commandlineResponse()));
+    abortCommandline = vi.fn(() => of({}));
+
     TestBed.configureTestingModule({
       imports: [CommandlineResultComponent],
       providers: [
@@ -24,8 +43,8 @@ describe('CommandlineResultComponent', () => {
         {
           provide: DuplicatiServer,
           useValue: {
-            getApiV1CommandlineByRunid: vi.fn(() => of({})),
-            postApiV1CommandlineByRunidAbort: vi.fn(() => of({})),
+            getApiV1CommandlineByRunid: getCommandline,
+            postApiV1CommandlineByRunidAbort: abortCommandline,
           },
         },
       ],
@@ -51,8 +70,9 @@ describe('CommandlineResultComponent', () => {
   });
 
   afterEach(() => {
-    clearInterval(component.interval);
-    fixture.destroy();
+    if (!fixture.componentRef.hostView.destroyed) fixture.destroy();
+    config.onUnhandledError = previousUnhandledError;
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -83,5 +103,68 @@ describe('CommandlineResultComponent', () => {
 
     expect(component.autoScrollEnabled()).toBe(true);
     expect(logOutput.scrollTop).toBe(300);
+  });
+
+  it('reads every page before marking a finished command as complete', async () => {
+    const lines = Array.from({ length: 250 }, (_, index) => `line ${index + 1}`);
+    const requestedOffsets: number[] = [];
+    getCommandline.mockImplementation((options: { query: { offset: number } }) => {
+      const offset = options.query.offset;
+      requestedOffsets.push(offset);
+
+      return of(
+        commandlineResponse({
+          Offset: offset,
+          Count: lines.length,
+          Items: lines.slice(offset, offset + 100),
+          Finished: true,
+        })
+      );
+    });
+
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(requestedOffsets).toEqual([0, 100, 200]);
+    expect(component.messageLog()).toEqual(lines);
+    expect(component.offset()).toBe(250);
+    expect(component.status()).toBe('finished');
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(getCommandline).toHaveBeenCalledTimes(3);
+  });
+
+  it('stops polling after a command lookup returns 404', async () => {
+    getCommandline.mockReturnValue(throwError(() => ({ status: 404 })));
+
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(getCommandline).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops polling when aborting a missing command returns 404', async () => {
+    abortCommandline.mockReturnValue(throwError(() => ({ error: { status: 404 } })));
+
+    component.abort();
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(abortCommandline).toHaveBeenCalledTimes(1);
+    expect(getCommandline).not.toHaveBeenCalled();
+    expect(component.status()).toBe('starting');
+  });
+
+  it('stops polling when the component is destroyed', async () => {
+    fixture.destroy();
+
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(getCommandline).not.toHaveBeenCalled();
+  });
+
+  it('continues polling after errors other than 404', async () => {
+    getCommandline.mockReturnValue(throwError(() => ({ error: { status: 503 } })));
+
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(getCommandline).toHaveBeenCalledTimes(2);
   });
 });

--- a/projects/ngclient/src/app/backup/commandline-result/commandline-result.component.ts
+++ b/projects/ngclient/src/app/backup/commandline-result/commandline-result.component.ts
@@ -112,12 +112,16 @@ export default class CommandlineResultComponent implements OnDestroy {
         this.status.set('aborted');
         this.#stopPolling();
       },
-      error: (error) => this.#handleError(error),
+      error: (error) => this.#handleError(error, 'finished'),
     });
   }
 
-  #handleError(error: unknown) {
-    if (getErrorStatus(error) === 404) this.#stopPolling();
+  #handleError(error: unknown, notFoundStatus?: Status) {
+    if (getErrorStatus(error) !== 404) return;
+
+    // A missing run is terminal: the server only removes runs that have finished
+    if (notFoundStatus) this.status.set(notFoundStatus);
+    this.#stopPolling();
   }
 
   #stopPolling() {

--- a/projects/ngclient/src/app/backup/commandline-result/commandline-result.component.ts
+++ b/projects/ngclient/src/app/backup/commandline-result/commandline-result.component.ts
@@ -5,6 +5,7 @@ import {
   computed,
   ElementRef,
   inject,
+  OnDestroy,
   signal,
   viewChild,
 } from '@angular/core';
@@ -18,6 +19,19 @@ import { CommandLineLogOutputDto, DuplicatiServer } from '../../core/openapi';
 
 type Status = 'starting' | 'started' | 'finished' | 'aborted';
 
+const getErrorStatus = (error: unknown): number | undefined => {
+  if (typeof error !== 'object' || error === null) return undefined;
+
+  const errorWithStatus = error as { status?: unknown; error?: unknown };
+  if (typeof errorWithStatus.status === 'number') return errorWithStatus.status;
+
+  const nestedError = errorWithStatus.error;
+  if (typeof nestedError !== 'object' || nestedError === null) return undefined;
+
+  const nestedStatus = (nestedError as { status?: unknown }).status;
+  return typeof nestedStatus === 'number' ? nestedStatus : undefined;
+};
+
 @Component({
   selector: 'app-commandline-result',
   imports: [StatusBarComponent, ShipIcon, ShipButton, RouterLink],
@@ -25,7 +39,7 @@ type Status = 'starting' | 'started' | 'finished' | 'aborted';
   styleUrl: './commandline-result.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export default class CommandlineResultComponent {
+export default class CommandlineResultComponent implements OnDestroy {
   #dupServer = inject(DuplicatiServer);
   #route = inject(ActivatedRoute);
   #routeParamsSignal = toSignal(this.#route.params);
@@ -48,7 +62,9 @@ export default class CommandlineResultComponent {
     logOutput.scrollTop = logOutput.scrollHeight;
   });
 
-  interval = setInterval(() => {
+  interval = setInterval(() => this.#poll(), 1000);
+
+  #poll() {
     defer(() =>
       this.#dupServer.getApiV1CommandlineByRunid({
         path: { runid: this.runId()! },
@@ -57,22 +73,30 @@ export default class CommandlineResultComponent {
           pagesize: 100,
         },
       })
-    ).subscribe((response) => {
-        this.offset.set(response.Count!);
+    ).subscribe({
+      next: (response) => {
+        const items = response.Items ?? [];
+        const nextOffset = (response.Offset ?? this.offset()) + items.length;
+
+        this.messageLog.update((messages) => [...messages, ...items]);
+        this.offset.set(nextOffset);
         this.evalStatus(response);
-        this.messageLog.update((y) => [...y, ...response.Items!]);
-      });
-  }, 1000);
+      },
+      error: (error) => this.#handleError(error),
+    });
+  }
 
   evalStatus(res: CommandLineLogOutputDto) {
-    if (res.Started === true && res.Finished === true) {
+    if (res.Started !== true) return;
+
+    const caughtUp = this.offset() >= (res.Count ?? this.offset());
+    if (res.Finished === true && caughtUp) {
       this.status.set('finished');
-      clearInterval(this.interval);
+      this.#stopPolling();
+      return;
     }
 
-    if (res.Started === true && res.Finished === false) {
-      this.status.set('started');
-    }
+    this.status.set('started');
   }
 
   updateAutoScroll() {
@@ -84,10 +108,23 @@ export default class CommandlineResultComponent {
 
   abort() {
     defer(() => this.#dupServer.postApiV1CommandlineByRunidAbort({ path: { runid: this.runId() } })).subscribe({
-      next: (res) => {
+      next: () => {
         this.status.set('aborted');
-        clearInterval(this.interval);
+        this.#stopPolling();
       },
+      error: (error) => this.#handleError(error),
     });
+  }
+
+  #handleError(error: unknown) {
+    if (getErrorStatus(error) === 404) this.#stopPolling();
+  }
+
+  #stopPolling() {
+    clearInterval(this.interval);
+  }
+
+  ngOnDestroy() {
+    this.#stopPolling();
   }
 }


### PR DESCRIPTION
## Symptom

Long-running commandline operations can show only part of their output and later produce a repeating "Command not found" alert every second. The reporter saw a 41-minute delete/compact stop at 438 lines without the usual return-code line.

## Root causes

This fixes three independent client-side defects:

1. **The polling offset skipped buffered output.** The server returns at most the requested page size in `Items`, while `Count` is the total number of available log lines. The component advanced its offset directly to `Count`, so more than 100 lines written between polls left a permanent gap. The server behavior is visible in [Commandline.cs at `330774f039d62bd0eff0aec62cf2be31df834fec`](https://github.com/duplicati/duplicati/blob/330774f039d62bd0eff0aec62cf2be31df834fec/Duplicati/WebserverCore/Endpoints/V1/Commandline.cs#L52-L78).
2. **A 404 did not stop polling.** The GET subscription had no error handler, so a missing command left the one-second interval running. Finished runs are eventually removed by the server cleanup described in [CommandlineRunService.cs at the same immutable revision](https://github.com/duplicati/duplicati/blob/330774f039d62bd0eff0aec62cf2be31df834fec/Duplicati/WebserverCore/Services/CommandlineRunService.cs#L204-L224).
3. **Component destruction did not clean up the interval.** Navigating away left the timer alive; the previous test suite had to clear it manually.

The component also stopped as soon as `Finished` became true, even if the current response showed that unread lines remained.

## Changes

- Advance the offset with the echoed `Offset + Items.length`.
- Keep polling a finished run until the consumed offset reaches `Count`, then mark it finished.
- Stop polling on GET or abort 404 responses, including the error shape wrapped by the HTTP interceptor.
- Keep polling after non-404 errors so transient failures can recover.
- Clear the interval when the component is destroyed.
- Preserve the existing abort-success state and auto-scroll behavior.

No server API, generated OpenAPI code, or HTTP interceptor is changed.

## Red to green

Before the production change, the expanded component suite had 4 failures and 3 passes:

- the 250-line scenario requested only offset 0 and retained only the first 100 lines
- GET 404 continued for three observed polling ticks
- abort 404 continued for three observed polling ticks
- destruction continued for three observed polling ticks
- the two existing auto-scroll tests and the non-404 continuation control passed

After the fix:

- targeted component suite: 7 tests passed
- full suite: 28 files and 283 tests passed, including all 278 pre-existing tests
- `bun install --frozen-lockfile`: no changes
- Prettier check: passed for both changed files
- production Angular build: passed

Validation used mise-managed Node 24.20.0 and Bun 1.4.0.

## Not measured

I did not reproduce the original 41-minute command in a live GUI. The user-visible evidence comes from the issue report, the immutable server implementation above, and deterministic fake-timer component tests. No Playwright or manual server run was performed.

Fixes #474